### PR TITLE
Flexible storage account

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ tmp-clearbox/
 MODULE.*
 .bazelrc
 .vscode/
+cred_helper.py

--- a/README.md
+++ b/README.md
@@ -79,17 +79,17 @@ Example of using a Bazel artifact server
 If you only have a single Google account that you use for Google Cloud locally, you can use
 `--google_default_credentials`.
 
-Otherwise, Bazel appears to have some trouble picking the correct account. The workaround is to
-use `--google_credentials` where the account can be specified explicitly.
+If you are use multiple google accounts, using the default credentials can be cumbersome when
+switching between projects. To avoid this, you can use the `--credential_helper` option
+instead, and pass a script that fetches credentials for the account you want to use. This
+account needs to have logged in using `gcloud auth login` and have access to the bucket
+specified.
 
-Set up a Google Cloud bucket and add the following to `.bazelrc`:
-
-    build --remote_cache=https://storage.googleapis.com/megaboom-bazel-artifacts --google_credentials=/home/oyvind/Downloads/innate-diode-408109-9c5d0543f9b3.json --remote_cache_compression=true
-
-To create the .json file:
-
-- create a service account. Only service account can have application keys.
-- add service account to bucket and give it permissions to read/write/list as appropriate
+To use this feature, copy the `cred_helper_template.py` file to `cred_helper.py` and replace
+the `USER` variable with the username you would like to use. An example `.bazelrc` file for
+this scenario would look like this:
+  
+    build --credential_helper=%workspace%/cred_helper.py --remote_cache=https://storage.googleapis.com/megaboom-bazel-artifacts --remote_cache_compression=true
 
 To gain access to the https://storage.googleapis.com/megaboom-bazel-artifacts bucket,
 reach out to Tom Spyrou, Precision Innovations (https://www.linkedin.com/in/tomspyrou/).

--- a/cred_helper_template.py
+++ b/cred_helper_template.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+
+import subprocess
+import json
+import sys
+
+
+USER = "google-cloud-username"
+
+
+def get_gcloud_auth_token():
+    try:
+        # Run gcloud command to get the authentication token
+        result = subprocess.run(
+            ["gcloud", "auth", "print-access-token", USER],
+            capture_output=True, text=True, check=True)
+        token = result.stdout.strip()
+        return token
+    except subprocess.CalledProcessError as e:
+        sys.exit(f"Error running gcloud command: {e}")
+
+
+def generate_credentials():
+    # Get the Bearer token from gcloud
+    bearer_token = get_gcloud_auth_token()
+
+    # Create the JSON object with the required format
+    credentials = {
+        "headers": {
+            "Authorization": [f"Bearer {bearer_token}"]
+        }
+    }
+
+    return credentials
+
+
+def main():
+    if len(sys.argv) != 2 or sys.argv[1] != "get":
+        sys.exit("Usage: python credential_helper.py get")
+
+    credentials = generate_credentials()
+    print(json.dumps(credentials, indent=2))
+
+
+if __name__ == "__main__":
+    main()
+


### PR DESCRIPTION
This makes authentication to google cloud buckets more flexible, by editing the credential helper python script and changing the username, this affects which account bazel tries to use when authenticating with the bucket