### PR TITLE
.bazelrc: do not rely on parsing username

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,10 +106,11 @@ instead, and pass a script that fetches credentials for the account you want to 
 account needs to have logged in using `gcloud auth login` and have access to the bucket
 specified.
 
-To use this feature, copy the snippet below into `.bazelrc` and specify your username by modifying `# user: myname@openroad.tools`:
+To use this feature, copy the snippet below into `.bazelrc` and specify your email address by replacing `<USER_EMAIL>`:
 
-    # user: myname@openroad.tools
-    build --credential_helper=%workspace%/cred_helper.py --remote_cache=https://storage.googleapis.com/megaboom-bazel-artifacts --remote_cache_compression=true
+```bazel
+build --credential_helper="%workspace%/cred_helper.py <USER_EMAIL>" --remote_cache=https://storage.googleapis.com/megaboom-bazel-artifacts --remote_cache_compression=true
+```
 
 `cred_helper.py` will parse `.bazelrc` and look for
 the username in the comment.

--- a/cred_helper.py
+++ b/cred_helper.py
@@ -6,24 +6,21 @@ import re
 import sys
 
 
-def get_gcloud_auth_token():
+def get_gcloud_auth_token(user):
     with open(".bazelrc") as f:
         all = f.read()
-    # The username is in the .bazelrc file as "# user: <username>"
-    # fish it out using a regex
-    USER = re.search(r"# user: (.*)", all).group(1)
 
     # Run gcloud command to get the authentication token
     result = subprocess.run(
-        ["gcloud", "auth", "print-access-token", USER],
+        ["gcloud", "auth", "print-access-token", user],
         capture_output=True, text=True, check=True)
     token = result.stdout.strip()
     return token
 
 
-def generate_credentials():
+def generate_credentials(user):
     # Get the Bearer token from gcloud
-    bearer_token = get_gcloud_auth_token()
+    bearer_token = get_gcloud_auth_token(user)
 
     # Create the JSON object with the required format
     credentials = {
@@ -35,10 +32,10 @@ def generate_credentials():
 
 
 def main():
-    if len(sys.argv) != 2 or sys.argv[1] != "get":
-        sys.exit("Usage: python credential_helper.py get")
+    if len(sys.argv) != 2:
+        sys.exit("Usage: python credential_helper.py <USER_EMAIL>")
 
-    credentials = generate_credentials()
+    credentials = generate_credentials(sys.argv[1])
     print(json.dumps(credentials, indent=2))
 
 


### PR DESCRIPTION
This is a suggestion on how to pass the user email without relying on parsing the `.bazelrc` file with Python, but still keeping the info in the `.bazelrc` file.