### PR TITLE
WORKSPACE: remove aspect_bazel_lib dependency

### DIFF
--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -1,16 +1,5 @@
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
-http_archive(
-    name = "aspect_bazel_lib",
-    sha256 = "e3151d87910f69cf1fc88755392d7c878034a69d6499b287bcfc00b1cf9bb415",
-    strip_prefix = "bazel-lib-1.32.1",
-    url = "https://github.com/aspect-build/bazel-lib/releases/download/v1.32.1/bazel-lib-v1.32.1.tar.gz",
-)
-
-load("@aspect_bazel_lib//lib:repositories.bzl", "aspect_bazel_lib_dependencies")
-
-aspect_bazel_lib_dependencies()
-
 #git_hash = ""
 #archive_sha256 = ""
 #


### PR DESCRIPTION
This PR depends on changes from https://github.com/The-OpenROAD-Project/bazel-orfs/pull/2.
 Dependency on [Aspect Bazel Lib](https://github.com/aspect-build/bazel-lib) is no longer required as the implementation of `build_openroad()` macro from [bazel-orfs](https://github.com/The-OpenROAD-Project/bazel-orfs) no longer uses `run_binary()` rule from `Aspect Bazel Lib`.
 
 CC @oharboe 