### PR TITLE
Fix env var cache invalidation

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,0 +1,1 @@
+build --incompatible_strict_action_env

--- a/.gitignore
+++ b/.gitignore
@@ -13,5 +13,4 @@ megaboom.qsf
 megaboom.qws
 tmp-clearbox/
 MODULE.*
-.bazelrc
 .vscode/


### PR DESCRIPTION
This PR starts tracking `.bazelrc` file and adds `--incompatible_strict_action_env` which enables strict environment control in bazel so that env vars like PATH in the host environment are not included in the build.