### PR TITLE
MODULE: Use upstream bazel-orfs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,7 @@ jobs:
         STAGE_TARGET:
           - tag_array_64x184_generate_abstract
           - L1MetadataArray_test_generate_abstract
+          - BoomTile_generate_abstract
           - regfile_128x65_floorplan
     env:
       DEBIAN_FRONTEND: "noninteractive"

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -7,8 +7,8 @@ module(
 bazel_dep(name = "bazel-orfs")
 git_override(
     module_name = "bazel-orfs",
-    remote = "https://github.com/antmicro/bazel-orfs.git",
-    commit = "08c9ec6508d42e48095af0195dee4349c79a99ce"
+    remote = "https://github.com/The-OpenROAD-Project/bazel-orfs.git",
+    commit = "c4fc0c549fde78560f5504e823c1283895e1effe",
 )
 
 #local_path_override(

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -1,6 +1,6 @@
 {
   "lockFileVersion": 3,
-  "moduleFileHash": "c4c435484be59380bf1f498269b5e8a9c4d6f6c59c486a8fc0f6c94852eb955b",
+  "moduleFileHash": "13f80b1a5a0afc3c54e277230468d706e9635dd12bef30eb3dbad8571c1eac28",
   "flags": {
     "cmdRegistries": [
       "https://bcr.bazel.build/"
@@ -56,7 +56,7 @@
               "tagName": "pull",
               "attributeValues": {
                 "name": "orfs_image",
-                "digest": "sha256:d41daa044c00628827ba9b4952fa3f9f07af16feab29fc02a9decfb257fb23ac",
+                "digest": "sha256:b13b35193bec45cb708bd9a5ee3546a7f20378e3c977a4c49f00e9c1c8a71181",
                 "image": "ghcr.io/antmicro/openroad-flow-scripts/ubuntu22.04",
                 "platforms": [
                   "linux/amd64"
@@ -1873,7 +1873,7 @@
               "scheme": "https",
               "registry": "ghcr.io",
               "repository": "antmicro/openroad-flow-scripts/ubuntu22.04",
-              "identifier": "sha256:d41daa044c00628827ba9b4952fa3f9f07af16feab29fc02a9decfb257fb23ac",
+              "identifier": "sha256:b13b35193bec45cb708bd9a5ee3546a7f20378e3c977a4c49f00e9c1c8a71181",
               "platforms": {
                 "@@platforms//cpu:x86_64": "@orfs_image_linux_amd64"
               },
@@ -2208,7 +2208,7 @@
               "scheme": "https",
               "registry": "ghcr.io",
               "repository": "antmicro/openroad-flow-scripts/ubuntu22.04",
-              "identifier": "sha256:d41daa044c00628827ba9b4952fa3f9f07af16feab29fc02a9decfb257fb23ac",
+              "identifier": "sha256:b13b35193bec45cb708bd9a5ee3546a7f20378e3c977a4c49f00e9c1c8a71181",
               "platform": "linux/amd64",
               "target_name": "orfs_image_linux_amd64"
             }


### PR DESCRIPTION
Pin [bazel-orfs](https://github.com/The-OpenROAD-Project/bazel-orfs) dependency to upstream repository. This is a follow up to https://github.com/The-OpenROAD-Project/megaboom/pull/29.

CC @oharboe 