### PR TITLE
Fix out script

### DIFF
--- a/out
+++ b/out
@@ -2,12 +2,11 @@
 
 # Find this path:
 #
-# /home/user/.cache/bazel/_bazel_user/7e6ad621f3f951c3ee6f5b179289b54e/sandbox/linux-sandbox/380/execroot/_main/bazel-out/k8-fastbuild/bin/
+# /home/user/.cache/bazel/_bazel_user/7e6ad621f3f951c3ee6f5b179289b54e/execroot/_main/bazel-out/k8-fastbuild/bin/
 #
 # Where:
 # _bazel_user is a folder where "user" is the username
 # 7e6ad621f3f951c3ee6f5b179289b54e is the most recent folder
-# 380 is the most recent folder
 #
 # Then print out the path
 
@@ -30,25 +29,12 @@ def find_path():
     for d in dirs:
         if not re.match(r'[a-z0-9]{32}', d):
             continue
-
-        path2 = os.path.join(path, d, "sandbox/linux-sandbox")
+        path2 = os.path.join(path, d,
+                             "execroot/_main/bazel-out/k8-fastbuild/bin")
         if not os.path.exists(path2):
             continue
 
-        dirs2 = os.listdir(path2)
-        dirs2.sort(key=lambda x: os.path.getmtime(os.path.join(path2, x)), reverse=True)
-        dirs2.reverse()
-
-        for d2 in dirs2:
-            if not re.match(r'[0-9]+', d2):
-                continue
-
-            path3 = os.path.join(path2, d2,
-                                 "execroot/_main/bazel-out/k8-fastbuild/bin")
-            if not os.path.exists(path3):
-                continue
-
-            return path3
+        return path2
 
     print("Could not find path")
     sys.exit(1)


### PR DESCRIPTION
`out` script assumed Bazel uses sandboxing. This PR corrects searched paths.