### PR TITLE
Fix local flow

### DIFF
--- a/.github/scripts/build_local_target.sh
+++ b/.github/scripts/build_local_target.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+set -e
+
+target_name=${TARGET:-"tag_array_64x184"}
+if [[ -z "$STAGES" ]]; then
+  if [[ "$target_name" == L1MetadataArray_* ]]; then
+    STAGES=("synth_sdc" "synth" "floorplan" "place" "cts" "grt" "generate_abstract")
+  else
+    STAGES=("synth_sdc" "synth" "memory" "floorplan" "generate_abstract")
+  fi
+else
+  eval "STAGES=($STAGES)"
+fi
+
+echo "Build tag_array_64x184 macro"
+for stage in ${STAGES[@]}
+do
+  if [[ -z $SKIP_BUILD ]] ; then
+    echo "query make script target"
+    bazel query ${target_name}_${stage}_make
+    bazel query ${target_name}_${stage}_make --output=build
+    echo "build make script"
+    bazel build --subcommands --verbose_failures --sandbox_debug ${target_name}_${stage}_make
+  fi
+  if [[ -z $SKIP_RUN ]] ; then
+    echo "run make script"
+    ./bazel-bin/${target_name}_${stage}_make $(if [[ "$stage" != "memory" ]] ; then echo "bazel-" ; fi)${stage}
+  fi
+done

--- a/.github/scripts/build_local_target.sh
+++ b/.github/scripts/build_local_target.sh
@@ -7,7 +7,7 @@ if [[ -z "$STAGES" ]]; then
   if [[ "$target_name" == L1MetadataArray_* ]]; then
     STAGES=("synth_sdc" "synth" "floorplan" "place" "cts" "grt" "generate_abstract")
   else
-    STAGES=("synth_sdc" "synth" "memory" "floorplan" "generate_abstract")
+    STAGES=("synth_sdc" "synth" "floorplan" "generate_abstract")
   fi
 else
   eval "STAGES=($STAGES)"
@@ -25,6 +25,6 @@ do
   fi
   if [[ -z $SKIP_RUN ]] ; then
     echo "run make script"
-    ./bazel-bin/${target_name}_${stage}_make $(if [[ "$stage" != "memory" ]] ; then echo "bazel-" ; fi)${stage}
+    ./bazel-bin/${target_name}_${stage}_make "bazel-"${stage}
   fi
 done

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,3 +45,47 @@ jobs:
       - name: build target
         run: |
           bazel build --subcommands --verbose_failures --sandbox_debug ${{ matrix.STAGE_TARGET }}
+
+  test-make-script-target:
+    name: Execute sample _make scripts
+    runs-on: ubuntu-22.04
+    container:
+      image: ghcr.io/antmicro/bazel-orfs@sha256:78b4c15830d75e026dc2294b280cb5ff1200f6ee7902a714dca71fd61b5b2e4e
+    defaults:
+      run:
+        shell: bash
+    strategy:
+      fail-fast: false
+    env:
+      DEBIAN_FRONTEND: "noninteractive"
+    steps:
+      # Workaround for https://github.com/actions/runner/issues/863
+      - name: Override HOME env var
+        shell: bash
+        run: |
+          echo HOME=/root | sudo tee -a $GITHUB_ENV
+      - name: Print info
+        run: |
+          echo "USER: "$(whoami)
+          echo "PWD: "$(pwd)
+          ls -la
+          echo "HOME: "$HOME
+          cd ~/OpenROAD-flow-scripts
+          echo "OpenROAD-flow-scripts SHA: "$(git rev-parse HEAD)
+          source ./env.sh
+          yosys --version
+          openroad -version
+      - name: Checkout megaboom
+        uses: actions/checkout@v4
+      - name: build local stage targets - tag_array_64x184
+        env:
+          TARGET: tag_array_64x184
+        run: .github/scripts/build_local_target.sh
+      - name: build local stage targets - lb_32x128
+        env:
+          TARGET: lb_32x128
+        run: .github/scripts/build_local_target.sh
+      - name: build local stage targets - L1MetadataArray_test
+        env:
+          TARGET: L1MetadataArray_test
+        run: .github/scripts/build_local_target.sh

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -8,5 +8,9 @@ bazel_dep(name = "bazel-orfs")
 git_override(
     module_name = "bazel-orfs",
     remote = "https://github.com/antmicro/bazel-orfs.git",
-    commit = "9c6a77edd9c6e431f578f28e01fa631765061fd2"
+    commit = "08c9ec6508d42e48095af0195dee4349c79a99ce"
 )
+
+#local_path_override(
+#    module_name = "bazel-orfs", path = "../bazel-orfs"
+#)

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -1,6 +1,6 @@
 {
   "lockFileVersion": 3,
-  "moduleFileHash": "162dacd209b29225f1ae0758bc8a140632e01b5a752c9f5c857e0627786eb24b",
+  "moduleFileHash": "c4c435484be59380bf1f498269b5e8a9c4d6f6c59c486a8fc0f6c94852eb955b",
   "flags": {
     "cmdRegistries": [
       "https://bcr.bazel.build/"


### PR DESCRIPTION
CC @oharboe 

This is a follow up PR to https://github.com/The-OpenROAD-Project/megaboom/pull/34

It pins the `bazel-orfs` version to the one from https://github.com/The-OpenROAD-Project/bazel-orfs/pull/20 which should fix the local flow.

There seems to be some kind of issue with build for the `L1MetadataArray`, however the macros build properly. Please check this on your local machine.