### PR TITLE
abstracts: create mock SRAMs after CTS

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -618,7 +618,7 @@ build_openroad(
                 'grt': ['SKIP_INCREMENTAL_REPAIR=1']
                 },
         mock_abstract=True,
-        mock_stage='floorplan',
+        mock_stage='cts',
         mock_area=0.6
         )
 
@@ -745,7 +745,7 @@ digital_top_srams=["cc_dir_1024x168",
                         'CORE_ASPECT_RATIO=2'],
                 'place': ['PLACE_DENSITY=0.65']},
         mock_abstract=True,
-        mock_stage='floorplan',
+        mock_stage='cts',
         mock_area={'tag_array_64x184':0.20,
         'meta_40x240':0.3,
         'data_data_40x128':1,
@@ -768,7 +768,7 @@ big_rams = ['mem_8192x64', 'cc_banks_16384x64', 'TLROM', 'ghist_40x72']
                         'CORE_ASPECT_RATIO=2'],
                 'place': ['PLACE_DENSITY=0.65']},
         mock_abstract=True,
-        mock_stage='floorplan',
+        mock_stage='cts',
         mock_area={'ghist_40x72':1}.get(ram, 0.30)
         ) for ram in big_rams if ram != 'TLROM']
 
@@ -784,7 +784,7 @@ build_openroad(
                         'CORE_ASPECT_RATIO=2'],
                 'place': ['PLACE_DENSITY=0.65']},
         mock_abstract=True,
-        mock_stage='floorplan',
+        mock_stage='cts',
         mock_area=0.40
         )
 
@@ -809,7 +809,7 @@ boom_regfile_rams = [
                 {'regfile_128x64':'0.42', 'regfile_128x65':'0.3'}.get(ram, '0.10')],
         },
         mock_abstract=True,
-        mock_stage='floorplan',
+        mock_stage='cts',
         mock_area={'regfile_128x64':0.4, 'regfile_128x65':0.4}.get(ram, 0.8)
         )
  for ram in boom_regfile_rams]
@@ -860,7 +860,7 @@ build_openroad(
                 'place': ['PLACE_DENSITY=0.20', 'PLACE_PINS_ARGS=-annealing'],
                 },
         mock_abstract=True,
-        mock_stage='floorplan'
+        mock_stage='cts'
         )
 
 build_openroad(
@@ -883,7 +883,7 @@ build_openroad(
                 'place': ['PLACE_DENSITY=0.20'],
                 },
         mock_abstract=True,
-        mock_stage='floorplan',
+        mock_stage='cts',
         mock_area=0.25
         )
 
@@ -904,7 +904,7 @@ build_openroad(
                 'place': ['PLACE_DENSITY=0.30'],
                 },
         mock_abstract=True,
-        mock_stage='floorplan',
+        mock_stage='cts',
         mock_area=0.33
         )
 
@@ -927,7 +927,7 @@ build_openroad(
                 'grt': ['SKIP_INCREMENTAL_REPAIR=1']
                 },
         mock_abstract=True,
-        mock_stage='floorplan',
+        mock_stage='cts',
         mock_area=0.3
         )
 
@@ -959,7 +959,7 @@ build_openroad(
                 },
         io_constraints=":io",
         mock_abstract=True,
-        mock_stage='floorplan',
+        mock_stage='cts',
         mock_area=0.20
         )
 


### PR DESCRIPTION
mock SRAMs after floorplan have pathological timing

This should fix the pathological slack seen here in the clock tree. The macros is the right branch of the clock tree and the clock tree should end roughly horizontal for all elements(as little slack as possible):

![image](https://github.com/The-OpenROAD-Project/megaboom/assets/2798822/59d0d15b-570f-417c-9e91-410d7c31c200)
