### PR TITLE
CI: Fix used stages for local flow tests

### DIFF
--- a/.github/scripts/build_local_target.sh
+++ b/.github/scripts/build_local_target.sh
@@ -4,11 +4,7 @@ set -e
 
 target_name=${TARGET:-"tag_array_64x184"}
 if [[ -z "$STAGES" ]]; then
-  if [[ "$target_name" == L1MetadataArray_* ]]; then
-    STAGES=("synth_sdc" "synth" "floorplan" "place" "cts" "grt" "generate_abstract")
-  else
-    STAGES=("synth_sdc" "synth" "floorplan" "generate_abstract")
-  fi
+  STAGES=("synth_sdc" "synth" "floorplan" "place" "cts" "generate_abstract")
 else
   eval "STAGES=($STAGES)"
 fi


### PR DESCRIPTION
This PR corrects stages used for local flow tests.

CI will fail due to unrelated `[ERROR RSZ-0060] Max buffer count reached.` like on [main branch](https://github.com/The-OpenROAD-Project/megaboom/actions/runs/8708125043/job/23884744619#step:7:4378)