### PR TITLE
tests: create abstract for L1MetadataArray from place instead of CTS for now

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,4 +107,5 @@ jobs:
       - name: build local stage targets - L1MetadataArray_test
         env:
           TARGET: L1MetadataArray_test
+          STAGES: synth_sdc synth floorplan place cts generate_abstract
         run: .github/scripts/build_local_target.sh

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -860,7 +860,7 @@ build_openroad(
                 'place': ['PLACE_DENSITY=0.20', 'PLACE_PINS_ARGS=-annealing'],
                 },
         mock_abstract=True,
-        mock_stage='cts'
+        mock_stage='place'
         )
 
 build_openroad(


### PR DESCRIPTION
…

More recent versions of ORFS have better handling of impossible timing repair after CTS and hence repair timing after CTS now fails.

The debug facilities are currently broken, so wait for those to be fixed before finding the problem with the constraint files or other settings with this test case before trying to re-enable.