### PR TITLE
CI: Remove CTS stage from L1MetadataArray test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,5 +107,5 @@ jobs:
       - name: build local stage targets - L1MetadataArray_test
         env:
           TARGET: L1MetadataArray_test
-          STAGES: synth_sdc synth floorplan place cts generate_abstract
+          STAGES: synth_sdc synth floorplan place generate_abstract
         run: .github/scripts/build_local_target.sh


### PR DESCRIPTION
This PR fixes CI error ([no such target](https://github.com/The-OpenROAD-Project/megaboom/actions/runs/8767647318/job/24061138603#step:8:1228)) by removing CTS from executed stages.