### PR TITLE
CI: Add testcase for open targets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,6 +109,11 @@ jobs:
           TARGET: L1MetadataArray_test
           STAGES: synth_sdc synth floorplan place generate_abstract
         run: .github/scripts/build_local_target.sh
+      - name: open targets
+        run: |
+          for stage in "synth" "floorplan" "place"; do
+            echo | bazel-bin/L1MetadataArray_test_${stage}_local_make open_${stage}
+          done
 
   test-make-scripts-target-docker:
     name: Docker flow - test _scripts tartgets
@@ -147,3 +152,9 @@ jobs:
           TARGET: L1MetadataArray_test
           STAGES: synth_sdc synth floorplan place generate_abstract
         run: .github/scripts/build_local_target.sh
+      - name: open target
+        if: matrix.STAGE_TARGET == 'L1MetadataArray_test_generate_abstract'
+        run: |
+          for stage in "synth" "floorplan" "place"; do
+            echo | bazel-bin/L1MetadataArray_test_${stage}_docker open_${stage}
+          done

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -8,7 +8,7 @@ bazel_dep(name = "bazel-orfs")
 git_override(
     module_name = "bazel-orfs",
     remote = "https://github.com/The-OpenROAD-Project/bazel-orfs.git",
-    commit = "00c6eae3cfa8bdd127928587f01e9cc38036a18a",
+    commit = "c3833cbf3e5eb0da1264dc34bcb923ada3c1eb39",
 )
 
 # Read: https://github.com/The-OpenROAD-Project/megaboom?tab=readme-ov-file#local-workspace

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -1,6 +1,6 @@
 {
   "lockFileVersion": 3,
-  "moduleFileHash": "46aec5a948402b68136932a2f6dc323964b76214280a3015ada35526cfe2126d",
+  "moduleFileHash": "d3f4a2449e6dc736b45c5392bce24124a4931dc276f64ba55aea4eafa97b10aa",
   "flags": {
     "cmdRegistries": [
       "https://bcr.bazel.build/"

--- a/README.md
+++ b/README.md
@@ -170,11 +170,11 @@ Hello world
 A quick test-build:
 
 ```
-# Build L1MetadataArray macro up to the CTS stage
-bazel build L1MetadataArray_test_cts
+# Build L1MetadataArray macro up to the placement stage and generate scripts
+bazel build L1MetadataArray_test_place_gui
 
 # View results with OpenROAD GUI
-bazel run L1MetadataArray_test_cts_gui
+./bazel-bin/L1MetadataArray_test_place_docker gui_place
 ```
 
 Staring at logs


### PR DESCRIPTION
This PR updates version of bazel-orfs and adds testcase for `open_{stage}` targets.