### PR TITLE
Bump bazel-orfs and ORFS docker image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,7 @@ jobs:
     name: Local flow - test _scripts tartgets
     runs-on: ubuntu-22.04
     container:
-      image: ghcr.io/antmicro/openroad-flow-scripts/ubuntu22.04@sha256:b13b35193bec45cb708bd9a5ee3546a7f20378e3c977a4c49f00e9c1c8a71181
+      image: ghcr.io/antmicro/openroad-flow-scripts/ubuntu22.04@sha256:ef18800147f1b09fd00366c32b2266da4944d59d588680ed05d2685fbae2531a
     defaults:
       run:
         shell: bash

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -8,7 +8,7 @@ bazel_dep(name = "bazel-orfs")
 git_override(
     module_name = "bazel-orfs",
     remote = "https://github.com/The-OpenROAD-Project/bazel-orfs.git",
-    commit = "c3833cbf3e5eb0da1264dc34bcb923ada3c1eb39",
+    commit = "4d9d5084270d7cfe51019f3cb6b886f6f8b57872",
 )
 
 # Read: https://github.com/The-OpenROAD-Project/megaboom?tab=readme-ov-file#local-workspace


### PR DESCRIPTION
CC @oharboe 

Bump bazel-orfs to the upstream version and update the CI workflow to use the newest ORFS docker image (built on top of https://github.com/The-OpenROAD-Project/OpenROAD-flow-scripts/commit/9b86e54c852ec4e77a94b7ba3c3bfcf012d6adba)