### PR TITLE
Move constraints dependencies to sources

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -12,8 +12,6 @@ filegroup(
     name = "io-sram",
     srcs = [
         "io-sram.tcl",
-    ],
-    data = [
         ":util",
     ],
     visibility = [":__subpackages__"],
@@ -23,8 +21,6 @@ filegroup(
     name = "io-boomtile",
     srcs = [
         "io-boomtile.tcl",
-    ],
-    data = [
         ":util",
     ],
 )
@@ -33,8 +29,6 @@ filegroup(
     name = "io",
     srcs = [
         "io.tcl",
-    ],
-    data = [
         ":util",
     ],
 )
@@ -43,8 +37,6 @@ filegroup(
     name = "io-top",
     srcs = [
         "io-top.tcl",
-    ],
-    data = [
         ":util",
     ],
 )
@@ -53,8 +45,6 @@ filegroup(
     name = "constraints-sram",
     srcs = [
         "constraints-sram.sdc",
-    ],
-    data = [
         ":util",
     ],
     visibility = [":__subpackages__"],

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -8,7 +8,7 @@ bazel_dep(name = "bazel-orfs")
 git_override(
     module_name = "bazel-orfs",
     remote = "https://github.com/The-OpenROAD-Project/bazel-orfs.git",
-    commit = "b434ee1b2fce89616f58f6bb0c2d6a6eeb540a85",
+    commit = "0c4160a9d8b372c562a979fc97614c1b0d573902",
 )
 
 # Read: https://github.com/The-OpenROAD-Project/megaboom?tab=readme-ov-file#local-workspace

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -1,6 +1,6 @@
 {
   "lockFileVersion": 3,
-  "moduleFileHash": "bf6a9e371451d6c56b1a3bbbc52c290371200dc404688212ba37d7268d2e2726",
+  "moduleFileHash": "8cc2554d1103502df2325b65b86087d8bf984a15ba04127d0e47207769b01d0f",
   "flags": {
     "cmdRegistries": [
       "https://bcr.bazel.build/"


### PR DESCRIPTION
This PR moves constraints dependencies from data to sources, so they are available during remote execution.