### PR TITLE
Update bazel-orfs version

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -8,7 +8,7 @@ bazel_dep(name = "bazel-orfs")
 git_override(
     module_name = "bazel-orfs",
     remote = "https://github.com/The-OpenROAD-Project/bazel-orfs.git",
-    commit = "72403c0ed232130a5ec23cb22c2c9608c03490e0",
+    commit = "9a0cea8bd1aa310348c54634778db4a35d28ed23",
 )
 
 # Read: https://github.com/The-OpenROAD-Project/bazel-orfs?tab=readme-ov-file#usage

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -1,6 +1,6 @@
 {
   "lockFileVersion": 3,
-  "moduleFileHash": "8cc2554d1103502df2325b65b86087d8bf984a15ba04127d0e47207769b01d0f",
+  "moduleFileHash": "e302d519d373ac468404c70d62fe2737f7358ee061a87cea500bf1c0ce9cdcfc",
   "flags": {
     "cmdRegistries": [
       "https://bcr.bazel.build/"

--- a/subpackage/BUILD
+++ b/subpackage/BUILD
@@ -6,6 +6,9 @@ build_openroad(
     abstract_stage = "floorplan",
     sdc_constraints = "//:constraints-sram",
     stage_args = {
+        "synth": [
+            "SYNTH_MEMORY_MAX_BITS=12000",
+        ],
         "floorplan": [
             "CORE_UTILIZATION=40",
             "CORE_ASPECT_RATIO=2",


### PR DESCRIPTION
This PR updates bazel-orfs to current main and increase max bits for memory to avoid `Synthesized memory size exceeds maximum allowed bits 4096` [error](https://github.com/antmicro/megaboom/actions/runs/9595093561/job/26459059234#step:7:247).