### PR TITLE
BUILD: fix gaffe in glob pattern when including *.sv and *.v files

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -72,7 +72,7 @@ mock_files = [
 ]
 
 all_source_files = sorted(glob(
-    include = ["rtl/*.(sv|v)"],
+    include = ["rtl/*.sv", "rtl/*.v"],
     exclude = ([f.replace("mock/", "rtl/") for f in mock_files] +
     ["rtl/ClockSourceAtFreqMHz.v",
     "rtl/SimJTAG.v",


### PR DESCRIPTION
@ivysochyn FYI