### PR TITLE
docker vestiges: delete

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,2 +1,2 @@
 build --incompatible_strict_action_env
-build --spawn_strategy=local
+try-import %workspace%/.user-bazelrc

--- a/.gitignore
+++ b/.gitignore
@@ -13,4 +13,4 @@ megaboom.qsf
 megaboom.qws
 tmp-clearbox/
 .vscode/
-copyright.txt
+.user-bazelrc

--- a/README.md
+++ b/README.md
@@ -44,12 +44,16 @@ instead, and pass a script that fetches credentials for the account you want to 
 account needs to have logged in using `gcloud auth login` and have access to the bucket
 specified.
 
-To use this feature, copy the snippet below into `.bazelrc` and specify your username by modifying `# user: myname@openroad.tools`:
+`.bazelrc` is under git version control and it will try to read in `.user-bazelrc`, which is
+not under git version control, which means that for git checkout or rebase operations will
+ignore the user configuration in `.user-bazelrc`.
+
+Copy the snippet below into `.user-bazelrc` and specify your username by modifying `# user: myname@openroad.tools`:
 
     # user: myname@openroad.tools
     build --credential_helper=%workspace%/cred_helper.py --remote_cache=https://storage.googleapis.com/megaboom-bazel-artifacts --remote_cache_compression=true
 
-`cred_helper.py` will parse `.bazelrc` and look for the username in the comment.
+`cred_helper.py` will parse `.user-bazelrc` and look for the username in the comment.
 
 > **Note:** To test the credential helper, make sure to restart Bazel to avoid using a previous
 cached authorization:

--- a/cred_helper.py
+++ b/cred_helper.py
@@ -7,9 +7,9 @@ import sys
 
 
 def get_gcloud_auth_token():
-    with open(".bazelrc") as f:
+    with open(".user-bazelrc") as f:
         all = f.read()
-    # The username is in the .bazelrc file as "# user: <username>"
+    # The username is in the .user-bazelrc file as "# user: <username>"
     # fish it out using a regex
     USER = re.search(r"# user: (.*)", all).group(1)
 


### PR DESCRIPTION
.bazelrc modifications are no longer needed