### PR TITLE
Update CI workflow for 'Local Flow' scenario

### DIFF
--- a/.github/scripts/build_local_target.sh
+++ b/.github/scripts/build_local_target.sh
@@ -13,15 +13,23 @@ echo "Build ${target_name} macro"
 for stage in "${STAGES[@]}"
 do
   if [[ -z $SKIP_BUILD ]] ; then
-    echo "query dependency target"
+    echo "[${target_name}] ${stage}: Query dependency target"
     bazel query "${target_name}_${stage}_deps"
     bazel query "${target_name}_${stage}_deps" --output=build
-    echo "build dependency"
+    echo "[${target_name}] ${stage}: Build dependency"
     bazel run --subcommands --verbose_failures --sandbox_debug "${target_name}_${stage}_deps" -- "$(pwd)/build"
   fi
   if [[ -z $SKIP_RUN ]] ; then
-    echo "run make script"
-    build/make "${stage}"
+    stages=()
+    if [[ $stage == "synth" ]]; then
+        stages+=("do-yosys-canonicalize" "do-yosys")
+    fi
+    stages+=("do-${stage}")
+    for local_stage in "${stages[@]}"
+    do
+        echo "[${target_name}] ${local_stage}: Run make script"
+        build/make "${local_stage}"
+    done
   fi
 done
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,7 +73,8 @@ jobs:
     name: Local flow - test targets
     runs-on: ubuntu-22.04
     container:
-      image: openroad/orfs:v3.0-1022-g69767b6a@sha256:adc74e5343a7638919f747eb74cbc67b5b71b18d9012608fef912ccee534c458
+      # NOTE: Ensure this is kept in sync with MODULE.bazel
+      image: openroad/orfs:v3.0-1114-g46acc762@sha256:ae4df23391c26bcc48a506f8e0d0da73742d1b6cb3b1dc02f4d5ea71170195b5
     defaults:
       run:
         shell: bash
@@ -149,7 +150,6 @@ jobs:
           STAGES: synth floorplan place
         run: .github/scripts/build_local_target.sh
       - name: Open target
-        if: matrix.STAGE_TARGET == 'L1MetadataArray_generate_abstract'
         run: |
           for stage in "floorplan" "place"; do
             echo | build/make open_${stage}

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -23,6 +23,7 @@ git_override(
 #)
 
 orfs = use_extension("@bazel-orfs//:extension.bzl", "orfs_repositories")
+# NOTE: Ensure this is kept in sync with CI
 orfs.default(
     image = "openroad/orfs:v3.0-1114-g46acc762",
     sha256 = "ae4df23391c26bcc48a506f8e0d0da73742d1b6cb3b1dc02f4d5ea71170195b5",


### PR DESCRIPTION
# Update CI workflow for 'Local Flow' scenario

This PR updates the local flow build process and the CI workflow to improve compatibility with the latest `bazel-orfs` changes.

This PR modifies the following:
* `.github/scripts/build_local_target.sh`
  * Modified flow to operate on 'in-place' stages (e.g. `do-floorplan` instead of `floorplan`)
  * Modified the script to handle additional sub-stages in the synthesis (`synth`) stage, including `do-yosys-canonicalize` and `do-yosys`
  * Updated logging to provide more detailed and specific output for each build and run stage

* `.github/workflows/ci.yml`
  * Updated the Docker image used in the local flow to `openroad/orfs:v3.0-1114-g46acc762` to align with the one used by the project. Resolves the incompatible database schema revision error
  * Removed an outdated conditional statement in the CI workflow that was no longer necessary