### PR TITLE
Automate Docker image tag extraction in CI workflow

### DIFF
--- a/.github/scripts/extract_docker_revision.py
+++ b/.github/scripts/extract_docker_revision.py
@@ -1,0 +1,65 @@
+import json
+from pathlib import Path
+import sys
+from typing import Optional
+
+
+def find_docker_orfs(data: dict) -> Optional[dict]:
+    """
+    Recursively search for the 'docker_orfs' configuration in
+    the provided JSON data.
+
+    Parameters
+    ----------
+    data : dict
+        The JSON data to search for the 'docker_orfs' configuration.
+
+    Returns
+    -------
+    Optional[dict]
+        The 'docker_orfs' configuration if found, otherwise None.
+    """
+    if isinstance(data, dict):
+        if 'docker_orfs' in data:
+            return data['docker_orfs']
+        for key, value in data.items():
+            result = find_docker_orfs(value)
+            if result:
+                return result
+    elif isinstance(data, list):
+        for item in data:
+            result = find_docker_orfs(item)
+            if result:
+                return result
+    return None
+
+
+if __name__ == "__main__":
+    if len(sys.argv) < 2 or not Path(sys.argv[1]).exists():
+        print(f"Usage: {sys.argv[0]} <MODULE.bazel>")
+        exit(1)
+
+    with open(sys.argv[1], 'r') as file:
+        try:
+            data = json.load(file)
+        except json.JSONDecodeError:
+            print(f"Unable to parse JSON data from {sys.argv[1]}")
+            exit(1)
+
+        docker_orfs = find_docker_orfs(data)
+        if docker_orfs is None or docker_orfs.get('attributes', None) is None:
+            print("Unable to find 'docker_orfs' configuration in the provided file")    # noqa: E501
+            exit(1)
+
+    docker_tag = docker_orfs.get('attributes').get('image', None)
+    docker_sha256 = docker_orfs.get('attributes').get('sha256', None)
+
+    if docker_tag is None or docker_sha256 is None:
+        print("Unable to find Docker tag or SHA256 in the provided file.")
+        exit(1)
+
+    print(json.dumps({
+            'image': f"{docker_tag}@sha256:{docker_sha256}",
+            'tag': docker_tag,
+            'sha256': docker_sha256
+    }))

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,20 @@ jobs:
         run: |
           buildifier -lint warn -r .
 
+  generate-config:
+    name: Generate configs
+    runs-on: ubuntu-latest
+    outputs:
+      docker-tag: ${{ steps.docker-image.outputs.docker-orfs }}
+    steps:
+      - name: Checkout megaboom
+        uses: actions/checkout@v4
+      - name: Lint Bazel files
+        run: bazel mod tidy && git diff --exit-code
+      - name: Extract Docker tag
+        id: docker-image
+        run: echo "docker-orfs=$(python3 .github/scripts/extract_docker_revision.py MODULE.bazel.lock)" | tee -a $GITHUB_OUTPUT
+
   test-make-target:
     name: ${{ matrix.STAGE_TARGET }}
     runs-on: ubuntu-22.04
@@ -68,18 +82,15 @@ jobs:
         run: |
           bazel run --subcommands --verbose_failures --sandbox_debug ${{ matrix.STAGE_TARGET }} -- `pwd`/build
 
-
   test-target-local:
     name: Local flow - test targets
     runs-on: ubuntu-22.04
+    needs: generate-config
     container:
-      # NOTE: Ensure this is kept in sync with MODULE.bazel
-      image: openroad/orfs:v3.0-1114-g46acc762@sha256:ae4df23391c26bcc48a506f8e0d0da73742d1b6cb3b1dc02f4d5ea71170195b5
+      image: ${{ fromJSON(needs.generate-config.outputs.docker-tag).image }}
     defaults:
       run:
         shell: bash
-    strategy:
-      fail-fast: false
     env:
       DEBIAN_FRONTEND: "noninteractive"
       FLOW_HOME: /OpenROAD-flow-scripts/flow
@@ -122,8 +133,6 @@ jobs:
     defaults:
       run:
         shell: bash
-    strategy:
-      fail-fast: false
     env:
       DEBIAN_FRONTEND: "noninteractive"
     steps:

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -23,7 +23,6 @@ git_override(
 #)
 
 orfs = use_extension("@bazel-orfs//:extension.bzl", "orfs_repositories")
-# NOTE: Ensure this is kept in sync with CI
 orfs.default(
     image = "openroad/orfs:v3.0-1114-g46acc762",
     sha256 = "ae4df23391c26bcc48a506f8e0d0da73742d1b6cb3b1dc02f4d5ea71170195b5",


### PR DESCRIPTION
# Automate Docker image tag extraction in CI workflow

This PR introduces a script to automate the extraction of Docker image tag information within the CI workflow and integrates it into the `ci.yml` GitHub Actions workflow. The purpose of this update is to enhance the maintainability of Docker image management within the project.

This PR modifies the following:
* `.github/scripts/extract_docker_revision.py` - Added a script that parses the `MODULE.bazel.lock` file to extract the Docker image tag and SHA256 checksum
* `.github/workflows/ci.yml`
  * Added a `generate-config` job to lint the `MODULE.bazel` and extract the Docker image tag using the introduced script
  * Updated the `test-target-local` job to dynamically reference the Docker image and SHA256 extracted by the `generate-config` job
* `MODULE.bazel` - Removed outdated comments related to Docker image synchronization in the CI pipeline