### PR TITLE
openroad/orfs:v3.0-1140-g64b0fca4

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -24,6 +24,6 @@ git_override(
 
 orfs = use_extension("@bazel-orfs//:extension.bzl", "orfs_repositories")
 orfs.default(
-    image = "openroad/orfs:v3.0-1114-g46acc762",
-    sha256 = "ae4df23391c26bcc48a506f8e0d0da73742d1b6cb3b1dc02f4d5ea71170195b5",
+    image = "openroad/orfs:v3.0-1140-g64b0fca4",
+    sha256 = "b046f91dcd5f31501962a654d3b3837e042ab1569e0253bb338d2694ab3e9180",
 )

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -64,7 +64,7 @@
     "@@bazel-orfs~//:extension.bzl%orfs_repositories": {
       "general": {
         "bzlTransitiveDigest": "42x9Wez2cJ4mcTzytkWEzBr9ilyB80Y3HGoSJdZwb6w=",
-        "usagesDigest": "oyTszwS5s5V4M2CXcdZAEJVpbhE4xwfh93FaP6U3epc=",
+        "usagesDigest": "rSawMYLhLbPGHjF8wwYojp+qcEKDIeoABKL95xzjEnI=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
         "envVariables": {},
@@ -73,8 +73,8 @@
             "bzlFile": "@@bazel-orfs~//:docker.bzl",
             "ruleClassName": "docker_pkg",
             "attributes": {
-              "image": "openroad/orfs:v3.0-1114-g46acc762",
-              "sha256": "ae4df23391c26bcc48a506f8e0d0da73742d1b6cb3b1dc02f4d5ea71170195b5",
+              "image": "openroad/orfs:v3.0-1140-g64b0fca4",
+              "sha256": "b046f91dcd5f31501962a654d3b3837e042ab1569e0253bb338d2694ab3e9180",
               "build_file": "@@bazel-orfs~//:docker.BUILD.bazel",
               "timeout": 3600
             }


### PR DESCRIPTION
@jeffng-or FYI

1. modify MODULE.bazel
2. ran `bazel mod tidy` to update MODULE.bazel.lock

Fails with the error message below, ChatGPT told me to run `sudo systemctl start docker` and it worked :-)

I think the problem is that ORFS `sudo ./setup.sh` is stopping docker...?

```
$ bazel build data_2048x8_generate_abstract
INFO: Invocation ID: d543c433-4374-474e-bacc-f90a9b1b228f
INFO: Repository bazel-orfs~~orfs_repositories~docker_orfs instantiated at:
  <builtin>: in <toplevel>
Repository rule docker_pkg defined at:
  /home/oyvind/.cache/bazel/_bazel_oyvind/7e6ad621f3f951c3ee6f5b179289b54e/external/bazel-orfs~/docker.bzl:55:29: in <toplevel>
ERROR: An error occurred during the fetch of repository 'bazel-orfs~~orfs_repositories~docker_orfs':
   Traceback (most recent call last):
	File "/home/oyvind/.cache/bazel/_bazel_oyvind/7e6ad621f3f951c3ee6f5b179289b54e/external/bazel-orfs~/docker.bzl", line 24, column 13, in _impl
		fail("Failed to build {}:".format(repository_ctx.attr.image), build_result.stderr)
Error in fail: Failed to build openroad/orfs:v3.0-1140-g64b0fca4: ERROR: Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?
ERROR: no such package '@@bazel-orfs~~orfs_repositories~docker_orfs//': Failed to build openroad/orfs:v3.0-1140-g64b0fca4: ERROR: Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?
ERROR: /home/oyvind/megaboom/BUILD.bazel:135:14: //:data_2048x8_generate_abstract depends on @@bazel-orfs~~orfs_repositories~docker_orfs//:gio_modules in repository @@bazel-orfs~~orfs_repositories~docker_orfs which failed to fetch. no such package '@@bazel-orfs~~orfs_repositories~docker_orfs//': Failed to build openroad/orfs:v3.0-1140-g64b0fca4: ERROR: Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?
ERROR: Analysis of target '//:data_2048x8_generate_abstract' failed; build aborted: Analysis failed
INFO: Elapsed time: 1.419s, Critical Path: 0.02s
INFO: 1 process: 1 internal.
ERROR: Build did NOT complete successfully
```

