### PR TITLE
floorplan: avoid repair_timing, which takes hours, in floorplan

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -244,6 +244,8 @@ orfs_flow(
             "CORE_UTILIZATION": "20",
             "MACRO_PLACE_HALO": "20 20",
             "RTLMP_FLOW": "1",
+            # repair_timing runs for hours in floorplan
+            "REMOVE_ABC_BUFFERS": "1",
         },
         "cts": SKIP_REPORT_METRICS | {
             "TNS_END_PERCENT": "0",


### PR DESCRIPTION
floorplan.tcl takes a very long time because repair_timing is called:

https://github.com/The-OpenROAD-Project/OpenROAD-flow-scripts/pull/2222/files#r1724866129
