### PR TITLE
Floorplan regfile flip flops

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -252,7 +252,12 @@ orfs_flow(
     verilog_files = ["rtl/L1MetadataArray.sv"],
 )
 
-boom_tile_macros = [x + "_generate_abstract" for x in boom_tile_rams + boom_regfile_rams.keys() + boom_tile_small_srams + digital_top_srams]
+boom_tile_macros = [x + "_generate_abstract" for x in (
+    boom_tile_rams +
+    # boom_regfile_rams.keys() +
+    boom_tile_small_srams +
+    digital_top_srams
+    )]
 
 orfs_flow(
     name = "BoomTile",

--- a/macros.tcl
+++ b/macros.tcl
@@ -1,142 +1,72 @@
-puts core.FpPipeline.fregfile.regfile_ext
 place_macro -macro_name core.FpPipeline.fregfile.regfile_ext -location {888.598 1741.44} -orientation MY
-puts core.iregfile.regfile_ext
 place_macro -macro_name core.iregfile.regfile_ext -location {982.368 140.67} -orientation R0
-puts dcache.data.array_0_0_ext
 place_macro -macro_name dcache.data.array_0_0_ext -location {343.386 451.344} -orientation MY
-puts dcache.data.array_0_1_ext
 place_macro -macro_name dcache.data.array_0_1_ext -location {343.386 329.136} -orientation MY
-puts dcache.data.array_1_0_ext
 place_macro -macro_name dcache.data.array_1_0_ext -location {505.066 451.344} -orientation MY
-puts dcache.data.array_1_1_ext
 place_macro -macro_name dcache.data.array_1_1_ext -location {505.066 329.136} -orientation MY
-puts dcache.data.array_2_0_ext
 place_macro -macro_name dcache.data.array_2_0_ext -location {585.906 329.136} -orientation MY
-puts dcache.data.array_2_1_ext
 place_macro -macro_name dcache.data.array_2_1_ext -location {100.866 329.136} -orientation MY
-puts dcache.data.array_3_0_ext
 place_macro -macro_name dcache.data.array_3_0_ext -location {20.026 329.136} -orientation MY
-puts dcache.data.array_3_1_ext
 place_macro -macro_name dcache.data.array_3_1_ext -location {424.226 329.136} -orientation MY
-puts dcache.data.array_4_0_ext
 place_macro -macro_name dcache.data.array_4_0_ext -location {424.226 451.344} -orientation MY
-puts dcache.data.array_4_1_ext
 place_macro -macro_name dcache.data.array_4_1_ext -location {100.866 451.344} -orientation MY
-puts dcache.data.array_5_0_ext
 place_macro -macro_name dcache.data.array_5_0_ext -location {262.546 451.344} -orientation MY
-puts dcache.data.array_5_1_ext
 place_macro -macro_name dcache.data.array_5_1_ext -location {181.706 329.136} -orientation MY
-puts dcache.data.array_6_0_ext
 place_macro -macro_name dcache.data.array_6_0_ext -location {585.906 451.344} -orientation MY
-puts dcache.data.array_6_1_ext
 place_macro -macro_name dcache.data.array_6_1_ext -location {20.026 451.344} -orientation MY
-puts dcache.data.array_7_0_ext
 place_macro -macro_name dcache.data.array_7_0_ext -location {262.546 329.136} -orientation MY
-puts dcache.data.array_7_1_ext
 place_macro -macro_name dcache.data.array_7_1_ext -location {181.706 451.344} -orientation MY
-puts dcache.meta_0.tag_array_ext
 place_macro -macro_name dcache.meta_0.tag_array_ext -location {802.58 20.064} -orientation R0
-puts dcache.meta_1.tag_array_ext
 place_macro -macro_name dcache.meta_1.tag_array_ext -location {891.736 20.064} -orientation R0
-puts dcache.mshrs.lb_ext
 place_macro -macro_name dcache.mshrs.lb_ext -location {705.258 129.552} -orientation R180
-puts dcache.mshrs.sdq_ext
 place_macro -macro_name dcache.mshrs.sdq_ext -location {705.258 20.064} -orientation MY
-puts frontend.bpd.banked_predictors_0.bim.data_ext
 place_macro -macro_name frontend.bpd.banked_predictors_0.bim.data_ext -location {20.026 859.92} -orientation MY
-puts frontend.bpd.banked_predictors_0.btb.btb_0_ext
 place_macro -macro_name frontend.bpd.banked_predictors_0.btb.btb_0_ext -location {20.026 573.552} -orientation MY
-puts frontend.bpd.banked_predictors_0.btb.btb_1_ext
 place_macro -macro_name frontend.bpd.banked_predictors_0.btb.btb_1_ext -location {136.776 573.552} -orientation R0
-puts frontend.bpd.banked_predictors_0.btb.ebtb_ext
 place_macro -macro_name frontend.bpd.banked_predictors_0.btb.ebtb_ext -location {20.026 774.06} -orientation R180
-puts frontend.bpd.banked_predictors_0.btb.meta_0_ext
 place_macro -macro_name frontend.bpd.banked_predictors_0.btb.meta_0_ext -location {253.526 573.552} -orientation R0
-puts frontend.bpd.banked_predictors_0.btb.meta_1_ext
 place_macro -macro_name frontend.bpd.banked_predictors_0.btb.meta_1_ext -location {405.7 573.552} -orientation R0
-puts frontend.bpd.banked_predictors_0.tage.t.table_ext
 place_macro -macro_name frontend.bpd.banked_predictors_0.tage.t.table_ext -location {2070.674 1363.584} -orientation R0
-puts frontend.bpd.banked_predictors_0.tage.t_1.table_ext
 place_macro -macro_name frontend.bpd.banked_predictors_0.tage.t_1.table_ext -location {2070.674 1186.272} -orientation MX
-puts frontend.bpd.banked_predictors_0.tage.t_2.hi_us_ext
 place_macro -macro_name frontend.bpd.banked_predictors_0.tage.t_2.hi_us_ext -location {2107.556 505.344} -orientation R0
-puts frontend.bpd.banked_predictors_0.tage.t_2.lo_us_ext
 place_macro -macro_name frontend.bpd.banked_predictors_0.tage.t_2.lo_us_ext -location {2107.556 608.256} -orientation R0
-puts frontend.bpd.banked_predictors_0.tage.t_2.table_ext
 place_macro -macro_name frontend.bpd.banked_predictors_0.tage.t_2.table_ext -location {1963.652 505.344} -orientation MY
-puts frontend.bpd.banked_predictors_0.tage.t_3.hi_us_ext
 place_macro -macro_name frontend.bpd.banked_predictors_0.tage.t_3.hi_us_ext -location {2107.556 852.096} -orientation R0
-puts frontend.bpd.banked_predictors_0.tage.t_3.lo_us_ext
 place_macro -macro_name frontend.bpd.banked_predictors_0.tage.t_3.lo_us_ext -location {2107.556 749.184} -orientation R0
-puts frontend.bpd.banked_predictors_0.tage.t_3.table_ext
 place_macro -macro_name frontend.bpd.banked_predictors_0.tage.t_3.table_ext -location {1963.652 749.184} -orientation MY
-puts frontend.bpd.banked_predictors_0.tage.t_4.table_ext
 place_macro -macro_name frontend.bpd.banked_predictors_0.tage.t_4.table_ext -location {2064.68 994.896} -orientation MX
-puts frontend.bpd.banked_predictors_0.tage.t_5.table_ext
 place_macro -macro_name frontend.bpd.banked_predictors_0.tage.t_5.table_ext -location {1905.823 992.928} -orientation MX
-puts frontend.bpd.banked_predictors_1.bim.data_ext
 place_macro -macro_name frontend.bpd.banked_predictors_1.bim.data_ext -location {20.026 910.848} -orientation MY
-puts frontend.bpd.banked_predictors_1.btb.btb_0_ext
 place_macro -macro_name frontend.bpd.banked_predictors_1.btb.btb_0_ext -location {20.026 1362.816} -orientation MY
-puts frontend.bpd.banked_predictors_1.btb.btb_1_ext
 place_macro -macro_name frontend.bpd.banked_predictors_1.btb.btb_1_ext -location {136.776 1362.816} -orientation R0
-puts frontend.bpd.banked_predictors_1.btb.ebtb_ext
 place_macro -macro_name frontend.bpd.banked_predictors_1.btb.ebtb_ext -location {20.026 1259.424} -orientation MY
-puts frontend.bpd.banked_predictors_1.btb.meta_0_ext
 place_macro -macro_name frontend.bpd.banked_predictors_1.btb.meta_0_ext -location {253.526 1259.424} -orientation R0
-puts frontend.bpd.banked_predictors_1.btb.meta_1_ext
 place_macro -macro_name frontend.bpd.banked_predictors_1.btb.meta_1_ext -location {405.7 1259.424} -orientation R0
-puts frontend.bpd.banked_predictors_1.tage.t.table_ext
 place_macro -macro_name frontend.bpd.banked_predictors_1.tage.t.table_ext -location {233.081 2002.08} -orientation R180
-puts frontend.bpd.banked_predictors_1.tage.t_1.table_ext
 place_macro -macro_name frontend.bpd.banked_predictors_1.tage.t_1.table_ext -location {20.026 1751.856} -orientation R180
-puts frontend.bpd.banked_predictors_1.tage.t_2.hi_us_ext
 place_macro -macro_name frontend.bpd.banked_predictors_1.tage.t_2.hi_us_ext -location {2107.556 364.314} -orientation MX
-puts frontend.bpd.banked_predictors_1.tage.t_2.lo_us_ext
 place_macro -macro_name frontend.bpd.banked_predictors_1.tage.t_2.lo_us_ext -location {2107.556 261.36} -orientation R0
-puts frontend.bpd.banked_predictors_1.tage.t_2.table_ext
 place_macro -macro_name frontend.bpd.banked_predictors_1.tage.t_2.table_ext -location {1965.695 261.36} -orientation R0
-puts frontend.bpd.banked_predictors_1.tage.t_3.hi_us_ext
 place_macro -macro_name frontend.bpd.banked_predictors_1.tage.t_3.hi_us_ext -location {20.026 1968.714} -orientation R180
-puts frontend.bpd.banked_predictors_1.tage.t_3.lo_us_ext
 place_macro -macro_name frontend.bpd.banked_predictors_1.tage.t_3.lo_us_ext -location {20.026 2075.802} -orientation R180
-puts frontend.bpd.banked_predictors_1.tage.t_3.table_ext
 place_macro -macro_name frontend.bpd.banked_predictors_1.tage.t_3.table_ext -location {91.373 1935.072} -orientation MX
-puts frontend.bpd.banked_predictors_1.tage.t_4.table_ext
 place_macro -macro_name frontend.bpd.banked_predictors_1.tage.t_4.table_ext -location {20.026 1556.88} -orientation R180
-puts frontend.bpd.banked_predictors_1.tage.t_5.table_ext
 place_macro -macro_name frontend.bpd.banked_predictors_1.tage.t_5.table_ext -location {20.026 964.224} -orientation MY
-puts frontend.ftq.meta_ext
 place_macro -macro_name frontend.ftq.meta_ext -location {139.24 1041.696} -orientation R180
-puts frontend.icache.dataArrayB0Way_0_ext
 place_macro -macro_name frontend.icache.dataArrayB0Way_0_ext -location {225.934 20.064} -orientation MY
-puts frontend.icache.dataArrayB0Way_1_ext
 place_macro -macro_name frontend.icache.dataArrayB0Way_1_ext -location {88.662 117.84} -orientation MY
-puts frontend.icache.dataArrayB0Way_2_ext
 place_macro -macro_name frontend.icache.dataArrayB0Way_2_ext -location {88.662 20.064} -orientation MY
-puts frontend.icache.dataArrayB0Way_3_ext
 place_macro -macro_name frontend.icache.dataArrayB0Way_3_ext -location {157.298 20.064} -orientation MY
-puts frontend.icache.dataArrayB0Way_4_ext
 place_macro -macro_name frontend.icache.dataArrayB0Way_4_ext -location {20.026 117.84} -orientation MY
-puts frontend.icache.dataArrayB0Way_5_ext
 place_macro -macro_name frontend.icache.dataArrayB0Way_5_ext -location {225.934 117.84} -orientation MY
-puts frontend.icache.dataArrayB0Way_6_ext
 place_macro -macro_name frontend.icache.dataArrayB0Way_6_ext -location {20.026 20.064} -orientation MY
-puts frontend.icache.dataArrayB0Way_7_ext
 place_macro -macro_name frontend.icache.dataArrayB0Way_7_ext -location {157.298 117.84} -orientation MY
-puts frontend.icache.dataArrayB1Way_0_ext
 place_macro -macro_name frontend.icache.dataArrayB1Way_0_ext -location {567.541 20.064} -orientation R0
-puts frontend.icache.dataArrayB1Way_1_ext
 place_macro -macro_name frontend.icache.dataArrayB1Way_1_ext -location {430.269 117.84} -orientation MY
-puts frontend.icache.dataArrayB1Way_2_ext
 place_macro -macro_name frontend.icache.dataArrayB1Way_2_ext -location {636.177 117.84} -orientation R0
-puts frontend.icache.dataArrayB1Way_3_ext
 place_macro -macro_name frontend.icache.dataArrayB1Way_3_ext -location {498.905 117.84} -orientation MY
-puts frontend.icache.dataArrayB1Way_4_ext
 place_macro -macro_name frontend.icache.dataArrayB1Way_4_ext -location {567.541 117.84} -orientation R0
-puts frontend.icache.dataArrayB1Way_5_ext
 place_macro -macro_name frontend.icache.dataArrayB1Way_5_ext -location {430.269 20.064} -orientation MY
-puts frontend.icache.dataArrayB1Way_6_ext
 place_macro -macro_name frontend.icache.dataArrayB1Way_6_ext -location {498.905 20.064} -orientation MY
 place_macro -macro_name frontend.icache.dataArrayB1Way_7_ext -location {636.177 20.064} -orientation R0
 place_macro -macro_name frontend.icache.tag_array_ext -location {294.57 20.064} -orientation MY

--- a/macros.tcl
+++ b/macros.tcl
@@ -1,5 +1,5 @@
-place_macro -macro_name core.FpPipeline.fregfile.regfile_ext -location {888.598 1741.44} -orientation MY
-place_macro -macro_name core.iregfile.regfile_ext -location {982.368 140.67} -orientation R0
+# place_macro -macro_name core.FpPipeline.fregfile.regfile_ext -location {888.598 1741.44} -orientation MY
+# place_macro -macro_name core.iregfile.regfile_ext -location {982.368 140.67} -orientation R0
 place_macro -macro_name dcache.data.array_0_0_ext -location {343.386 451.344} -orientation MY
 place_macro -macro_name dcache.data.array_0_1_ext -location {343.386 329.136} -orientation MY
 place_macro -macro_name dcache.data.array_1_0_ext -location {505.066 451.344} -orientation MY


### PR DESCRIPTION
We can easily switch back and forth between regfile macro and regfile flattened at top level, merge with master so we can inspect the artifacts.

Running times are tolerable... Largely the same.

```
Log                            Elapsed seconds Peak Memory/MB
1_1_yosys                                 7034           6011
1_1_yosys_canonicalize                      19           1421
1_1_yosys_hier_report                        0             11
No elapsed time found in logs/asap7/BoomTile/base/1_1_yosys_metrics.log
2_1_floorplan                              118           4454
2_2_floorplan_io                            14           2798
No elapsed time found in logs/asap7/BoomTile/base/2_3_floorplan_tdms.log
2_4_floorplan_macro                         16           2757
No elapsed time found in logs/asap7/BoomTile/base/2_5_floorplan_tapcell.log
2_6_floorplan_pdn                          379          22734
3_1_place_gp_skip_io                      2238           6460
3_2_place_iop                               29           3442
3_3_place_gp                              2598          22410
3_4_place_resized                          315           5661
3_5_place_dp                               789          19139
4_1_cts                                    248          19527
5_1_grt                                   1682          59805
No elapsed time found in logs/asap7/BoomTile/base/5_1_grt.tmp.log
5_2_fillcell                               143          24569
5_3_route                                28783          61337
Total                                    44405          61337
```
