### PR TITLE
Orfs bump

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -265,7 +265,7 @@ orfs_flow(
     arguments = SKIP_REPORT_METRICS | {
             # We only need hierarchical synthesis when we are running through floorplan
             # write_macro_placement macros.tcl
-            "SYNTH_HIERARCHICAL": "0",
+            "SYNTH_HIERARCHICAL": "1",
             "SDC_FILE": "$(location :constraints-boomtile)",
         } | BLOCKS_FLOORPLAN | BOOMTILE_FLOOR_PLACE_ARGUMENTS | SKIP_REPORT_METRICS | {
             #"CORE_UTILIZATION": "20",
@@ -273,7 +273,7 @@ orfs_flow(
             # macro placement
             "MACRO_PLACE_HALO": "19 19",
             "RTLMP_FLOW": "1",
-            "MACRO_PLACEMENT_TCL": "$(location :boomtile-macro-placement)",
+            # "MACRO_PLACEMENT_TCL": "$(location :boomtile-macro-placement)",
         } | SKIP_REPORT_METRICS | {
             "TNS_END_PERCENT": "0",
             "SKIP_CTS_REPAIR_TIMING": "1",

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -157,7 +157,7 @@ digital_top_srams = [
     orfs_flow(
         name = ram,
         abstract_stage = "cts",
-        stage_args = {
+        stage_arguments = {
             "synth": SRAM_SYNTH_ARGUMENTS | {"SYNTH_MEMORY_MAX_BITS": "16384"},
             "floorplan": BLOCK_FLOORPLAN | SRAM_FLOOR_PLACE_ARGUMENTS | {
                 "CORE_UTILIZATION": "40",
@@ -201,7 +201,7 @@ boom_regfile_rams = {
     orfs_flow(
         name = ram,
         abstract_stage = "cts",
-        stage_args = {
+        stage_arguments = {
             "synth": SRAM_SYNTH_ARGUMENTS,
             "floorplan": BLOCK_FLOORPLAN | {
                 # "CORE_UTILIZATION": "200",
@@ -232,7 +232,7 @@ orfs_flow(
     name = "L1MetadataArray",
     abstract_stage = "place",
     macros = ["tag_array_64x184_generate_abstract"],
-    stage_args = {
+    stage_arguments = {
         "synth": SRAM_SYNTH_ARGUMENTS | {"SYNTH_HIERARCHICAL": "1"},
         "floorplan": BLOCKS_FLOORPLAN | FLOOR_PLACE_ARGUMENTS | {
             "CORE_UTILIZATION": "3",
@@ -262,7 +262,7 @@ boom_tile_macros = [x + "_generate_abstract" for x in (
 orfs_flow(
     name = "BoomTile",
     macros = boom_tile_macros,
-    args = SKIP_REPORT_METRICS | {
+    arguments = SKIP_REPORT_METRICS | {
             # We only need hierarchical synthesis when we are running through floorplan
             # write_macro_placement macros.tcl
             "SYNTH_HIERARCHICAL": "0",

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -15,7 +15,7 @@ module(
 bazel_dep(name = "bazel-orfs")
 git_override(
     module_name = "bazel-orfs",
-    commit = "01e36cbb55e42a2d4ac3df10780ba4b077a42931",
+    commit = "3ccb566d81cffde6d21e0d6c3af5e1ce614c8aa2",
     remote = "https://github.com/The-OpenROAD-Project/bazel-orfs.git",
 )
 
@@ -28,8 +28,14 @@ git_override(
 # $ docker buildx imagetools inspect openroad/flow-ubuntu22.04-builder --format "{{json .Manifest.Digest}}"
 # "sha256:5d4d20d3d5638fa5c79b05c6f9b240c7e5691bf8b6c47c9a46d9bb0e0d53bb09"
 # $ bazel mod tidy
-orfs = use_extension("@bazel-orfs//:extension.bzl", "orfs_repositories")
-orfs.default(
-    image = "docker.io/openroad/orfs:v3.0-1343-g091a06bf",
-    sha256 = "90743d244bd6379675eca8ce99ad0db383a4f25c0c73469bb7d64e5d4bc8aa2c",
-)
+
+# ORFS is provided as a transitive dependency from bazel-orfs, but
+# it is possible to specify a version in here if something newer than
+# latest bazel-orfs tested ORFS is needed.
+
+#orfs = use_extension("@bazel-orfs//:extension.bzl", "orfs_repositories")
+#
+#orfs.default(
+#    image = "docker.io/openroad/orfs:v3.0-1459-gd505a82b",
+#    sha256 = "434edf30b4d0610c17cb0cd4f865ba8ce34f7b247904bd2a8ba6e17b89981c37",
+#)


### PR DESCRIPTION
@jeffng-or @hovind FYI

- mpl2 no longer crashes, there has been a tiny change in initial conditions. A [fix](https://github.com/The-OpenROAD-Project/OpenROAD/pull/5799) is on its way.
- "args" to "arguments" update in orfs_flow() API
- ORFS is now a transitive dependency. We use, by default, the version of ORFS that bazel-orfs uses. For now this is good 'nuf and more convenient, though in the future, if megaboom updates ORFS much more frequently than bazel-orfs, it could be better to specify ORFS version in megaboom.