### PR TITLE
example of mock_area issue in megaboom

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -157,6 +157,7 @@ digital_top_srams = [
     orfs_flow(
         name = ram,
         abstract_stage = "cts",
+        mock_area = 0.65,
         stage_arguments = {
             "synth": SRAM_SYNTH_ARGUMENTS | {"SYNTH_MEMORY_MAX_BITS": "16384"},
             "floorplan": BLOCK_FLOORPLAN | SRAM_FLOOR_PLACE_ARGUMENTS | {


### PR DESCRIPTION
I'm trying to run the mock_area flow in megaboom to repro other errors:

```
bazel build sdq_17x64_generate_abstract
...
[WARNING STA-0366] port 'clock' not found.
[WARNING STA-0473] no valid objects specified for -to.
[WARNING STA-0471] no valid objects specified for -from.
[WARNING STA-0473] no valid objects specified for -to.
[ERROR STA-0391] group_path command failed.
Error: constraints.sdc, 87 STA-0391
```

Doesn't occur when running in the bazel-orfs example flow, but it's also using a different constraints file.

Guessing that my sram SDC constraints change needs to go in first so that the clocks are properly registered. But, sharing just in case I'm way off.