### PR TITLE
example of sram mock_area flow failing due to shared output file name…

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -123,45 +123,54 @@ all_source_files = sorted(glob(
     ]),
 ) + mock_files)
 
-boom_tile_small_srams = [
-    "tag_array_64x184",
-    "tag_array_64x168",
-    # "data_2048x2",
-    "table_256x48",
-    "table_128x52",
-    "table_128x44",
-    "btb_128x56",
-    "meta_128x120",
-    "lb_32x128",
-    "sdq_17x64",
-    "data_2048x8",
-    "mem_256x4",
-]
+# Only run mock_area flow on SRAMs with non-None mock_area values
+# Bazel conflict occurs when ebtb_128x40 and either meta_128x120 or sdq_17x64
+# are enabled together
+boom_tile_small_srams = {
+    "tag_array_64x184": { "mock_area": None, "aspect_ratio": "2" },
+    "tag_array_64x168": { "mock_area": None, "aspect_ratio": "2" },
+    # "data_2048x2": { "mock_area": None, "aspect_ratio": "2" },
+    "table_256x48": { "mock_area": None, "aspect_ratio": "2" },
+    "table_128x52": { "mock_area": None, "aspect_ratio": "2" },
+    "table_128x44": { "mock_area": None, "aspect_ratio": "2" },
+    "btb_128x56": { "mock_area": None, "aspect_ratio": "2" },
+    "meta_128x120": { "mock_area": None, "aspect_ratio": "2" },
+    "lb_32x128": { "mock_area": None, "aspect_ratio": "2" },
+    "sdq_17x64": { "mock_area": 1.0, "aspect_ratio": "2" },
+    "data_2048x8": { "mock_area": None, "aspect_ratio": "2" },
+    "mem_256x4": { "mock_area": None, "aspect_ratio": "2" },
+}
 
-boom_tile_rams = [
-    # "l2_tlb_ram_0_512x46",
-    "ebtb_128x40",
-    "array_256x128",
-    "dataArrayB_256x64",
-    # "l2_tlb_ram_0_512x45",
-]
+boom_tile_rams = {
+    # "l2_tlb_ram_0_512x46": { "mock_area": None, "aspect_ratio": "2" },
+    "ebtb_128x40": { "mock_area": 1.0, "aspect_ratio": "2" },
+    "array_256x128": { "mock_area": None, "aspect_ratio": "2" },
+    "dataArrayB_256x64": { "mock_area": None, "aspect_ratio": "2" },
+    # "l2_tlb_ram_0_512x45": { "mock_area": None, "aspect_ratio": "2" },
+}
 
-digital_top_srams = [
-    # "cc_dir_1024x168",
-    # "data_data_40x128",
-    # "ghist_40x64",
-    "meta_40x240",
-]
+digital_top_srams = {
+    # "cc_dir_1024x168": { "mock_area": None, "aspect_ratio": "2" },
+    # "data_data_40x128": { "mock_area": None, "aspect_ratio": "2" },
+    # "ghist_40x64": { "mock_area": None, "aspect_ratio": "2" },
+    "meta_40x240": { "mock_area": None, "aspect_ratio": "2" },
+}
+
+# combine SRAMs into one dictionary for processing
+all_srams = boom_tile_rams
+all_srams |= boom_tile_small_srams
+all_srams |= digital_top_srams
 
 [
     orfs_flow(
         name = ram,
         abstract_stage = "cts",
+        mock_area = ram_data["mock_area"],
         stage_arguments = {
             "synth": SRAM_SYNTH_ARGUMENTS | {"SYNTH_MEMORY_MAX_BITS": "16384"},
             "floorplan": BLOCK_FLOORPLAN | SRAM_FLOOR_PLACE_ARGUMENTS | {
                 "CORE_UTILIZATION": "40",
-                "CORE_ASPECT_RATIO": "2",
+                "CORE_ASPECT_RATIO": ram_data["aspect_ratio"],
             },
             "place": SRAM_FLOOR_PLACE_ARGUMENTS | {
                 "PLACE_DENSITY": "0.65",
@@ -189,7 +198,7 @@ digital_top_srams = [
             }.get(ram, "rtl/") + ram + ".sv",
         ],
     )
-    for ram in boom_tile_rams + boom_tile_small_srams + digital_top_srams
+    for ram, ram_data in all_srams.items()
 ]
 
 boom_regfile_rams = {
@@ -252,12 +261,7 @@ orfs_flow(
     verilog_files = ["rtl/L1MetadataArray.sv"],
 )
 
-boom_tile_macros = [x + "_generate_abstract" for x in (
-    boom_tile_rams +
-    # boom_regfile_rams.keys() +
-    boom_tile_small_srams +
-    digital_top_srams
-    )]
+boom_tile_macros = [x + "_generate_abstract" for x in all_srams.keys()]
 
 orfs_flow(
     name = "BoomTile",


### PR DESCRIPTION
… definition

PR to share test case - do not merge

Enables mock_area flow for two SRAMs, which causes bazel-orfs to try and define the same output file for two different SRAMs.

Proposed fix in bazel-orfs PR: https://github.com/The-OpenROAD-Project/bazel-orfs/pull/180