### PR TITLE
Sram tweaks

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -128,13 +128,13 @@ all_source_files = sorted(glob(
 # with experiment notes on the same line
 boom_tile_small_srams = {
     "tag_array_64x184": {
-        "mock_area": 0.92,
+        "mock_area": 0.62,
         "aspect_ratio": "0.33",
-    },  # ran out of left edge pin slots
+    },
     "tag_array_64x168": {
-        "mock_area": 0.44,
+        "mock_area": 0.31,
         "aspect_ratio": "0.36",
-    },  # ran out of left edge pin slots
+    },
     # "data_2048x2": { "mock_area": None, "aspect_ratio": "2" },
     "table_256x48": {
         "mock_area": 0.31,
@@ -153,17 +153,17 @@ boom_tile_small_srams = {
         "aspect_ratio": "0.53",
     },  # close
     "meta_128x120": {
-        "mock_area": 0.79,
+        "mock_area": 0.31,
         "aspect_ratio": "0.25",
-    },  # ran out of left edge pin slots
+    },
     "lb_32x128": {
-        "mock_area": 0.34,
+        "mock_area": 0.32,
         "aspect_ratio": "0.93",
-    },  # ran out of left edge pin slots - can get within 70 um^2 by adjusting aspect ratio to 0.99
+    },
     "sdq_17x64": {
         "mock_area": 0.32,
         "aspect_ratio": "1.2",
-    },  # ran out of left edge pin slots - can get within 10 um^2 by adjusting aspect ratio to 1.37
+    },
     "data_2048x8": {
         "mock_area": 5.01,
         "aspect_ratio": "19",
@@ -209,6 +209,9 @@ all_srams = boom_tile_rams | boom_tile_small_srams | digital_top_srams
         name = ram,
         abstract_stage = "cts",
         mock_area = ram_data["mock_area"],
+        arguments = {
+            "PLACE_PINS_ARGS": "-min_distance 1 -min_distance_in_tracks",
+        },
         stage_arguments = {
             "synth": SRAM_SYNTH_ARGUMENTS | {"SYNTH_MEMORY_MAX_BITS": "16384"},
             "floorplan": BLOCK_FLOORPLAN | SRAM_FLOOR_PLACE_ARGUMENTS | {

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@bazel-orfs//:openroad.bzl", "orfs_flow")
+load("@bazel-orfs//:openroad.bzl", "orfs_flow", "orfs_run")
 
 filegroup(
     name = "io-sram",
@@ -209,10 +209,10 @@ all_srams = boom_tile_rams | boom_tile_small_srams | digital_top_srams
     orfs_flow(
         name = ram,
         abstract_stage = "cts",
-        mock_area = ram_data["mock_area"],
         arguments = {
             "PLACE_PINS_ARGS": "-min_distance 1 -min_distance_in_tracks",
         },
+        mock_area = ram_data["mock_area"],
         stage_arguments = {
             "synth": SRAM_SYNTH_ARGUMENTS | {"SYNTH_MEMORY_MAX_BITS": "16384"},
             "floorplan": BLOCK_FLOORPLAN | SRAM_FLOOR_PLACE_ARGUMENTS | {
@@ -247,6 +247,24 @@ all_srams = boom_tile_rams | boom_tile_small_srams | digital_top_srams
     )
     for ram, ram_data in all_srams.items()
 ]
+
+[orfs_run(
+    name = ram + "_report",
+    src = ":" + ram + "_floorplan",
+    outs = [
+        ram + ".yaml",
+    ],
+    arguments = {"OUTFILE": "$(location :" + ram + ".yaml)"},
+    script = ":report-sram.tcl",
+) for ram in all_srams.keys()]
+
+sh_binary(
+    name = "sram_report",
+    srcs = ["sram.py"],
+    args = ["$(location :" + ram + "_report)" for ram in all_srams.keys()],
+    data = [":" + ram + "_report" for ram in all_srams.keys()],
+    visibility = ["//visibility:public"],
+)
 
 boom_regfile_rams = {
     "regfile_128x64": ":io-sram-bottom",

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -165,12 +165,13 @@ boom_tile_small_srams = {
         "aspect_ratio": "1.2",
     },
     "data_2048x8": {
-        "mock_area": 5.01,
-        "aspect_ratio": "19",
-    },  # target aspect ratio not achievable - not enough space for metal straps
+        "mock_area": 3.2,
+        "aspect_ratio": "58",
+        "core_utilization": "10",
+    },
     "mem_256x4": {
         "mock_area": 0.265,
-        "aspect_ratio": "17.2",
+        "aspect_ratio": "36",
     },  # close
 }
 
@@ -215,7 +216,7 @@ all_srams = boom_tile_rams | boom_tile_small_srams | digital_top_srams
         stage_arguments = {
             "synth": SRAM_SYNTH_ARGUMENTS | {"SYNTH_MEMORY_MAX_BITS": "16384"},
             "floorplan": BLOCK_FLOORPLAN | SRAM_FLOOR_PLACE_ARGUMENTS | {
-                "CORE_UTILIZATION": "40",
+                "CORE_UTILIZATION": ram_data.get("core_utilization", "40"),
                 "CORE_ASPECT_RATIO": ram_data["aspect_ratio"],
             },
             "place": SRAM_FLOOR_PLACE_ARGUMENTS | {

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -81,6 +81,7 @@ BLOCK_FLOORPLAN = {
     # repair_timing runs for hours in floorplan
     "REMOVE_ABC_BUFFERS": "1",
 }
+
 BLOCKS_FLOORPLAN = {
     "PDN_TCL": "$(PLATFORM_DIR)/openRoad/pdn/BLOCKS_grid_strategy.tcl",
     # repair_timing runs for hours in floorplan
@@ -123,45 +124,96 @@ all_source_files = sorted(glob(
     ]),
 ) + mock_files)
 
-boom_tile_small_srams = [
-    "tag_array_64x184",
-    "tag_array_64x168",
-    # "data_2048x2",
-    "table_256x48",
-    "table_128x52",
-    "table_128x44",
-    "btb_128x56",
-    "meta_128x120",
-    "lb_32x128",
-    "sdq_17x64",
-    "data_2048x8",
-    "mem_256x4",
-]
+# Haven't tried mocking any SRAMs with mock_area of None. Rest have been tried
+# with experiment notes on the same line
+boom_tile_small_srams = {
+    "tag_array_64x184": {
+        "mock_area": 0.92,
+        "aspect_ratio": "0.33",
+    },  # ran out of left edge pin slots
+    "tag_array_64x168": {
+        "mock_area": 0.44,
+        "aspect_ratio": "0.36",
+    },  # ran out of left edge pin slots
+    # "data_2048x2": { "mock_area": None, "aspect_ratio": "2" },
+    "table_256x48": {
+        "mock_area": 0.31,
+        "aspect_ratio": "1.25",
+    },  #close
+    "table_128x52": {
+        "mock_area": 0.31,
+        "aspect_ratio": "0.58",
+    },  #close
+    "table_128x44": {
+        "mock_area": 0.31,
+        "aspect_ratio": "0.68",
+    },  # close
+    "btb_128x56": {
+        "mock_area": 0.309,
+        "aspect_ratio": "0.53",
+    },  # close
+    "meta_128x120": {
+        "mock_area": 0.79,
+        "aspect_ratio": "0.25",
+    },  # ran out of left edge pin slots
+    "lb_32x128": {
+        "mock_area": 0.34,
+        "aspect_ratio": "0.93",
+    },  # ran out of left edge pin slots - can get within 70 um^2 by adjusting aspect ratio to 0.99
+    "sdq_17x64": {
+        "mock_area": 0.32,
+        "aspect_ratio": "1.2",
+    },  # ran out of left edge pin slots - can get within 10 um^2 by adjusting aspect ratio to 1.37
+    "data_2048x8": {
+        "mock_area": 5.01,
+        "aspect_ratio": "19",
+    },  # target aspect ratio not achievable - not enough space for metal straps
+    "mem_256x4": {
+        "mock_area": 0.265,
+        "aspect_ratio": "17.2",
+    },  # close
+}
 
-boom_tile_rams = [
-    # "l2_tlb_ram_0_512x46",
-    "ebtb_128x40",
-    "array_256x128",
-    "dataArrayB_256x64",
-    # "l2_tlb_ram_0_512x45",
-]
+boom_tile_rams = {
+    # "l2_tlb_ram_0_512x46": { "mock_area": None, "aspect_ratio": "2" },
+    "ebtb_128x40": {
+        "mock_area": 0.86,
+        "aspect_ratio": "0.75",
+    },  # close
+    "array_256x128": {
+        "mock_area": 1.225,
+        "aspect_ratio": "0.47",
+    },  # close
+    "dataArrayB_256x64": {
+        "mock_area": 1.23,
+        "aspect_ratio": "0.94",
+    },  # close
+    # "l2_tlb_ram_0_512x45": { "mock_area": None, "aspect_ratio": "2" },
+}
 
-digital_top_srams = [
-    # "cc_dir_1024x168",
-    # "data_data_40x128",
-    # "ghist_40x64",
-    "meta_40x240",
-]
+digital_top_srams = {
+    # "cc_dir_1024x168": { "mock_area": None, "aspect_ratio": "2" },
+    # "data_data_40x128": { "mock_area": None, "aspect_ratio": "2" },
+    # "ghist_40x64": { "mock_area": None, "aspect_ratio": "2" },
+    "meta_40x240": {
+        "mock_area": 0.48,
+        "aspect_ratio": "0.64",
+    },  # ran out of left edge pin slots - can get closer by adjusting aspect ratio but only to within 1000 um^2
+}
+
+# combine SRAMs into one dictionary for processing
+all_srams = boom_tile_rams | boom_tile_small_srams | digital_top_srams
 
 [
     orfs_flow(
         name = ram,
         abstract_stage = "cts",
+        mock_area = ram_data["mock_area"],
         stage_arguments = {
             "synth": SRAM_SYNTH_ARGUMENTS | {"SYNTH_MEMORY_MAX_BITS": "16384"},
             "floorplan": BLOCK_FLOORPLAN | SRAM_FLOOR_PLACE_ARGUMENTS | {
                 "CORE_UTILIZATION": "40",
-                "CORE_ASPECT_RATIO": "2",
+                "CORE_ASPECT_RATIO": ram_data["aspect_ratio"],
             },
             "place": SRAM_FLOOR_PLACE_ARGUMENTS | {
                 "PLACE_DENSITY": "0.65",
@@ -189,7 +241,7 @@ digital_top_srams = [
             }.get(ram, "rtl/") + ram + ".sv",
         ],
     )
-    for ram in boom_tile_rams + boom_tile_small_srams + digital_top_srams
+    for ram, ram_data in all_srams.items()
 ]
 
 boom_regfile_rams = {
@@ -252,49 +304,47 @@ orfs_flow(
     verilog_files = ["rtl/L1MetadataArray.sv"],
 )
 
-boom_tile_macros = [x + "_generate_abstract" for x in (
-    boom_tile_rams +
-    # boom_regfile_rams.keys() +
-    boom_tile_small_srams +
-    digital_top_srams
-    )]
+boom_tile_macros = [x + "_generate_abstract" for x in all_srams.keys()]
 
 orfs_flow(
     name = "BoomTile",
-    macros = boom_tile_macros,
     arguments = SKIP_REPORT_METRICS | {
-            # We only need hierarchical synthesis when we are running through floorplan
-            # write_macro_placement macros.tcl
-            "SYNTH_HIERARCHICAL": "1",
-            "SDC_FILE": "$(location :constraints-boomtile)",
-        } | BLOCKS_FLOORPLAN | BOOMTILE_FLOOR_PLACE_ARGUMENTS | SKIP_REPORT_METRICS | {
-            #"CORE_UTILIZATION": "20",
-            # Tweak below to work around initial condition sensitive bugs in
-            # macro placement
-            "MACRO_PLACE_HALO": "19 19",
-            "RTLMP_FLOW": "1",
-            # "MACRO_PLACEMENT_TCL": "$(location :boomtile-macro-placement)",
-        } | SKIP_REPORT_METRICS | {
-            "TNS_END_PERCENT": "0",
-            "SKIP_CTS_REPAIR_TIMING": "1",
-        } | BOOMTILE_FLOOR_PLACE_ARGUMENTS | SKIP_REPORT_METRICS | {
-            "PLACE_PINS_ARGS": "-annealing",
-            "GPL_ROUTABILITY_DRIVEN": "1",
-            "GPL_TIMING_DRIVEN": "0",
-        } | SKIP_REPORT_METRICS | {
-            # Save global route time for now
-            "SKIP_INCREMENTAL_REPAIR": "1",
-            "MIN_ROUTING_LAYER": "M2",
-            "MAX_ROUTING_LAYER": "M7",
-            "ROUTING_LAYER_ADJUSTMENT": "0.45",
-            "DIE_AREA": "0 0 2300 2300",
-            "CORE_AREA": "1.026 1.08 2298 2298",
-            "FILL_CELLS": "",
-            "TAPCELL_TCL": "",
+        # We only need hierarchical synthesis when we are running through floorplan
+        # write_macro_placement macros.tcl
+        "SYNTH_HIERARCHICAL": "1",
+        "SDC_FILE": "$(location :constraints-boomtile)",
+    } | BLOCKS_FLOORPLAN | BOOMTILE_FLOOR_PLACE_ARGUMENTS | SKIP_REPORT_METRICS | {
+        #"CORE_UTILIZATION": "20",
+        # Tweak below to work around initial condition sensitive bugs in
+        # macro placement
+        "MACRO_PLACE_HALO": "19 19",
+        "RTLMP_FLOW": "1",
+        # "MACRO_PLACEMENT_TCL": "$(location :boomtile-macro-placement)",
+    } | SKIP_REPORT_METRICS | {
+        "TNS_END_PERCENT": "0",
+        "SKIP_CTS_REPAIR_TIMING": "1",
+    } | BOOMTILE_FLOOR_PLACE_ARGUMENTS | SKIP_REPORT_METRICS | {
+        "PLACE_PINS_ARGS": "-annealing",
+        "GPL_ROUTABILITY_DRIVEN": "1",
+        "GPL_TIMING_DRIVEN": "0",
+    } | SKIP_REPORT_METRICS | {
+        # Save global route time for now
+        "SKIP_INCREMENTAL_REPAIR": "1",
+        "MIN_ROUTING_LAYER": "M2",
+        "MAX_ROUTING_LAYER": "M7",
+        "ROUTING_LAYER_ADJUSTMENT": "0.45",
+        "DIE_AREA": "0 0 2300 2300",
+        "CORE_AREA": "1.026 1.08 2298 2298",
+        "FILL_CELLS": "",
+        "TAPCELL_TCL": "",
     },
+    macros = boom_tile_macros,
     stage_sources = {
         "synth": [":constraints-boomtile"],
-        "floorplan": [":io-boomtile", ":boomtile-macro-placement"],
+        "floorplan": [
+            ":io-boomtile",
+            ":boomtile-macro-placement",
+        ],
         "place": [":io-boomtile"],
     },
     verilog_files = all_source_files,

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -15,7 +15,7 @@ module(
 bazel_dep(name = "bazel-orfs")
 git_override(
     module_name = "bazel-orfs",
-    commit = "f6657610056afae51cf08dfe5f8b07cad7a03799",
+    commit = "f972a3dba3784356dbd84f4683be7d3bd4c5fe5b",
     remote = "https://github.com/The-OpenROAD-Project/bazel-orfs.git",
 )
 

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -61,6 +61,34 @@
   },
   "selectedYankedVersions": {},
   "moduleExtensions": {
+    "@@apple_support~//crosstool:setup.bzl%apple_cc_configure_extension": {
+      "general": {
+        "bzlTransitiveDigest": "PjIds3feoYE8SGbbIq2SFTZy3zmxeO2tQevJZNDo7iY=",
+        "usagesDigest": "aLmqbvowmHkkBPve05yyDNGN7oh7QE9kBADr3QIZTZs=",
+        "recordedFileInputs": {},
+        "recordedDirentsInputs": {},
+        "envVariables": {},
+        "generatedRepoSpecs": {
+          "local_config_apple_cc": {
+            "bzlFile": "@@apple_support~//crosstool:setup.bzl",
+            "ruleClassName": "_apple_cc_autoconf",
+            "attributes": {}
+          },
+          "local_config_apple_cc_toolchains": {
+            "bzlFile": "@@apple_support~//crosstool:setup.bzl",
+            "ruleClassName": "_apple_cc_autoconf_toolchains",
+            "attributes": {}
+          }
+        },
+        "recordedRepoMappingEntries": [
+          [
+            "apple_support~",
+            "bazel_tools",
+            "bazel_tools"
+          ]
+        ]
+      }
+    },
     "@@bazel-orfs~//:extension.bzl%orfs_repositories": {
       "general": {
         "bzlTransitiveDigest": "nbzG4yf/eg5a7s7gTfA+1gy5C3WdHDukeOhUvYZYbOc=",

--- a/report-sram.tcl
+++ b/report-sram.tcl
@@ -1,0 +1,23 @@
+source $::env(SCRIPTS_DIR)/load.tcl
+load_design 2_floorplan.odb 2_floorplan.sdc
+
+set f [open "$::env(OUTFILE)" w]
+foreach path_group {in2reg reg2out in2out reg2reg} {
+    set paths [find_timing_paths -path_group $path_group -sort_by_slack]
+    if {[llength $paths] == 0} {
+        set worst "N/A"
+    } else {
+        set points [get_property [lindex $paths 0] points]
+        set worst [get_property [lindex $points [expr [llength $points] - 1]] arrival]
+    }
+    puts $f "$path_group: $worst"
+}
+set db [::ord::get_db]
+set dbu_per_uu [expr double([[$db getTech] getDbUnitsPerMicron])]
+set block [[$db getChip] getBlock]
+set die_bbox [$block getDieArea]
+set scale [expr 1 / $dbu_per_uu]
+puts $f "width: [expr [$die_bbox xMax] * $scale]"
+puts $f "height: [expr [$die_bbox yMax] * $scale]"
+
+close $f

--- a/sram.py
+++ b/sram.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+import os
+import yaml
+import sys
+from tabulate import tabulate
+
+
+def main():
+    if len(sys.argv) == 1:
+        print("Usage: {} <files>".format(sys.argv[0]))
+        sys.exit(1)
+
+    srams = {}
+    for filename in sys.argv[1:]:
+        with open(filename, "r") as f:
+            srams[filename] = yaml.load(f, Loader=yaml.FullLoader)
+
+    list_of_list_of_all_columns = [list(sram.keys()) for sram in srams.values()]
+    all_columns = sorted(
+        list(set([item for sublist in list_of_list_of_all_columns for item in sublist]))
+    )
+    order = ["width", "height"]
+    all_columns = order + [col for col in all_columns if col not in order]
+
+    table_data = []
+
+    table_data.append(["Name"] + all_columns)
+
+    for sram, values in srams.items():
+        basename_without_ext = os.path.splitext(os.path.basename(sram))[0]
+        row = [basename_without_ext] + [
+            (
+                f"{float(values.get(col, '')):>10.2f}"
+                if isinstance(values.get(col, ""), (int, float))
+                or values.get(col, "").replace(".", "", 1).isdigit()
+                else str(values.get(col, ""))
+            )
+            for col in all_columns
+        ]
+        table_data.append(row)
+
+    print(tabulate(table_data, headers="firstrow", tablefmt="pipe"))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
@jeffng-or To generate a report with information about all the SRAMs, run:

```
$ bazel run sram_report
[deleted]
INFO: Running command line: bazel-bin/sram_report ./ebtb_128x40.yaml ./array_256x128.yaml ./dataArrayB_256x64.yaml ./tag_array_64x184.yaml ./tag_array_64x168.yaml ./table_256x48.yaml ./table_128x52.yaml ./table_128x44.yaml ./btb_128x56.yaml ./meta_128x120.yaml ./lb_32x128.yaml ./sdq_17x64.yaml ./data_2048x8.yaml ./mem_256x4.yaml ./meta_40x240.yaml
```

Outputs:

| Name              |   width |   height | in2out   |   in2reg |   reg2out |   reg2reg |
|:------------------|--------:|---------:|:---------|---------:|----------:|----------:|
| ebtb_128x40       |   40.04 |    30.53 | N/A      |   354.98 |    332.81 |    563.21 |
| array_256x128     |   87.58 |    42.22 | N/A      |   722.01 |   1083.76 |   5611.53 |
| dataArrayB_256x64 |   44.65 |    42.09 | N/A      |   537.17 |    554.27 |   4092.69 |
| tag_array_64x184  |  124.54 |    42.44 | N/A      |   185.72 |   8580.84 |    300.45 |
| tag_array_64x168  |  225.36 |    82.41 | N/A      |   358.48 | 117421    |     70.54 |
| table_256x48      |  131.23 |   163.54 | N/A      |   401.59 | 106057    |     69.05 |
| table_128x52      |  140.65 |    82.42 | N/A      |   311.71 |  74786.3  |     69.18 |
| table_128x44      |  119.83 |    82.12 | N/A      |   496.72 |  30568.8  |     68.9  |
| btb_128x56        |  152.3  |    81.66 | N/A      |   317.73 |  86403.9  |     69.33 |
| meta_128x120      |  321.1  |    81.78 | N/A      |   410.08 | 459115    |     71.83 |
| lb_32x128         |   86.32 |    80.42 | 305.84   |   855.85 |     95.15 |     80.95 |
| sdq_17x64         |   40.52 |    48.23 | 327.53   |   468.08 |     93.68 |     75.89 |
| data_2048x8       |    4.13 |   125.6  | N/A      |    61.61 |     61.83 |    149.97 |
| mem_256x4         |    9.5  |   271.93 | N/A      |   500.98 |   1278.84 |     83.25 |
| meta_40x240       |  159.77 |   102.98 | N/A      |  1512.6  |  25599.2  |     90.7  |
