### PR TITLE
orfs: bump

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -265,7 +265,7 @@ sram_report_stage = "place"
 
 [orfs_run(
     name = ram + "_floorplan_report",
-    src = ":" + ram + "_floorplan_mock_area",
+    src = ":" + ram + "_mocked_floorplan",
     outs = [
         ram + "_floorplan.yaml",
     ],

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -15,7 +15,7 @@ module(
 bazel_dep(name = "bazel-orfs")
 git_override(
     module_name = "bazel-orfs",
-    commit = "f972a3dba3784356dbd84f4683be7d3bd4c5fe5b",
+    commit = "eb517038a68f4e0655bb3fcfdb3e7d239e81cc69",
     remote = "https://github.com/The-OpenROAD-Project/bazel-orfs.git",
 )
 

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -92,7 +92,7 @@
     "@@bazel-orfs~//:extension.bzl%orfs_repositories": {
       "general": {
         "bzlTransitiveDigest": "nbzG4yf/eg5a7s7gTfA+1gy5C3WdHDukeOhUvYZYbOc=",
-        "usagesDigest": "r2yNWiPUcr3eY5XQFSOq4v2hM8EEWZQcfrFq3zmmZPo=",
+        "usagesDigest": "X0rQmwyYbFhyfp8pWLLQ8qu9snGYomiecRuxFpcH3DQ=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
         "envVariables": {},
@@ -101,8 +101,8 @@
             "bzlFile": "@@bazel-orfs~//:docker.bzl",
             "ruleClassName": "docker_pkg",
             "attributes": {
-              "image": "docker.io/openroad/orfs:v3.0-1496-g20cf8faa",
-              "sha256": "9fc4d6cd0f77d7a08039a204f2c9ef0fd26d191578526d56d57af4c76f722d50",
+              "image": "docker.io/openroad/orfs:v3.0-1534-g98c233e2",
+              "sha256": "cfb483e1fbf9ccfb89ddc85907eb0976e59b244584f0253b5379f18f9e0b359e",
               "build_file": "@@bazel-orfs~//:docker.BUILD.bazel",
               "timeout": 3600,
               "patch_cmds": [


### PR DESCRIPTION
```
bazel run sram_report
```

| Name              |   width |   height | in2out   |   in2reg |   reg2out |   reg2reg |
|:------------------|--------:|---------:|:---------|---------:|----------:|----------:|
| ebtb_128x40       |   34.43 |    26.25 | N/A      |   212.74 |    240.13 |    306.88 |
| array_256x128     |  107.28 |    51.72 | N/A      |   230.17 |    317.33 |    452.77 |
| dataArrayB_256x64 |   54.92 |    51.77 | N/A      |   267.01 |    248.73 |    411.09 |
| tag_array_64x184  |   77.22 |    26.31 | N/A      |   137.93 |    443.49 |    213.79 |
| tag_array_64x168  |   69.86 |    25.55 | N/A      |   208.81 |    706.36 |     64.53 |
| table_256x48      |   40.68 |    50.7  | N/A      |   217.13 |    509.76 |     70.16 |
| table_128x52      |   43.6  |    25.55 | N/A      |   202.11 |    729.65 |     70.18 |
| table_128x44      |   37.15 |    25.46 | N/A      |   228.99 |    613.93 |     70.05 |
| btb_128x56        |   47.06 |    25.23 | N/A      |   203.89 |    813.96 |     70.25 |
| meta_128x120      |   99.54 |    25.35 | N/A      |   228.64 |    864.05 |     65.07 |
| lb_32x128         |   27.62 |    25.73 | 518.64   |   249.86 |    115.76 |     71.13 |
| sdq_17x64         |   12.97 |    15.43 | 311.51   |   219.03 |    107.48 |     66.27 |
| data_2048x8       |   13.22 |   401.91 | N/A      |    79.34 |     66.65 |    131.23 |
| mem_256x4         |    2.52 |    72.06 | N/A      |   184.8  |    432.57 |     69.5  |
| meta_40x240       |   76.69 |    49.43 | N/A      |   347.34 |    515.65 |     65.31 |