### PR TITLE
cred_helper: add test mode, run without arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,18 @@ Copy the snippet below into `.user-bazelrc` and specify your username by modifyi
 
 `cred_helper.py` will parse `.user-bazelrc` and look for the username in the comment.
 
+To test, run:
+
+    $ ./cred_helper.py
+    Running: gcloud auth print-access-token oyvind@openroad.tools
+    {
+      "kind": "storage#testIamPermissionsResponse",
+      "permissions": [
+        "storage.buckets.get",
+        "storage.objects.create"
+      ]
+    }
+
 > **Note:** To test the credential helper, make sure to restart Bazel to avoid using a previous
 cached authorization:
 

--- a/cred_helper.py
+++ b/cred_helper.py
@@ -1,49 +1,66 @@
 #!/usr/bin/env python3
 
 import subprocess
+import requests
 import json
 import re
 import sys
 
 
-def get_gcloud_auth_token():
+def get_gcloud_auth_token(test):
     """
     Returns the gcloud auth token based on the .user-bazelrc
     """
-    
+
     with open(".user-bazelrc") as f:
         all = f.read()
-    # The username is in the .user-bazelrc file as "# user: <username>"
-    # fish it out using a regex
-    USER = re.search(r"# user: (.*)", all).group(1)
+    match = re.search(r"# user: (.*)", all)
+    if match is None:
+        sys.exit('Did not find username in .user-bazelrc file as "# user: <username>"')
+    USER = match.group(1)
 
-    # Run gcloud command to get the authentication token
-    result = subprocess.run(
-        ["gcloud", "auth", "print-access-token", USER],
-        capture_output=True, text=True, check=True)
+    cmd = ["gcloud", "auth", "print-access-token", USER]
+    if test:
+        print("Running: " + subprocess.list2cmdline(cmd))
+    result = subprocess.run(cmd, capture_output=True, text=True, check=True)
     token = result.stdout.strip()
     return token
 
 
-def generate_credentials():
-    # Get the Bearer token from gcloud
-    bearer_token = get_gcloud_auth_token()
+def generate_credentials(test):
+    bearer_token = get_gcloud_auth_token(test)
 
-    # Create the JSON object with the required format
-    credentials = {
-        "headers": {
-            "Authorization": [f"Bearer {bearer_token}"]
-        }
-    }
+    credentials = {"headers": {"Authorization": f"Bearer {bearer_token}"}}
     return credentials
 
 
-def main():
-    if len(sys.argv) != 2 or sys.argv[1] != "get":
-        sys.exit("Usage: python credential_helper.py get")
+def test_permissions(credentials, bucket_name):
+    url = (
+        f"https://storage.googleapis.com/storage/v1/b/{bucket_name}/iam/testPermissions"
+    )
+    permissions = {"permissions": ["storage.buckets.get", "storage.objects.create"]}
 
-    credentials = generate_credentials()
-    print(json.dumps(credentials, indent=2))
+    response = requests.get(url, params=permissions, headers=credentials["headers"])
+    response.raise_for_status()
+    return response.json()
+
+
+def main():
+    if len(sys.argv) > 2 or (len(sys.argv) == 2 and sys.argv[1] != "get"):
+        sys.exit(
+            "Tests or gets access credentials\n"
+            "Usage: python credential_helper.py [get]"
+        )
+    test = len(sys.argv) == 1
+
+    credentials = generate_credentials(test)
+    if not test:
+        print(json.dumps(credentials, indent=2))
+        return
+
+    permissions = test_permissions(credentials, "megaboom-bazel-artifacts")
+
+    print(json.dumps(permissions, indent=2))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
```
$ ./cred_helper.py
Running: gcloud auth print-access-token oyvind@openroad.tools {
  "kind": "storage#testIamPermissionsResponse",
  "permissions": [
    "storage.buckets.get",
    "storage.objects.create"
  ]
}
```