### PR TITLE
global routing: tweak macro placement to ease congestion

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -337,7 +337,7 @@ orfs_flow(
         #"CORE_UTILIZATION": "20",
         # Tweak below to work around initial condition sensitive bugs in
         # macro placement
-        "MACRO_PLACE_HALO": "19 19",
+        "MACRO_PLACE_HALO": "10 10",
         "RTLMP_FLOW": "1",
         # "MACRO_PLACEMENT_TCL": "$(location :boomtile-macro-placement)",
         "TNS_END_PERCENT": "0",


### PR DESCRIPTION
@jeffng-or I have been upgrading w.r.t. bazel-orfs fixes, saw this grt congestion.

Perhaps a bit less halo will leave more space in the middle?

![image](https://github.com/user-attachments/assets/42765fc9-9318-49ab-8c3d-25df73ae4fe9)
