### PR TITLE
changed clock period to 1200 / 833 MHz

### DIFF
--- a/constraints-boomtile.sdc
+++ b/constraints-boomtile.sdc
@@ -1,6 +1,10 @@
 set sdc_version 2.0
 
-set clk_period 1500
+#
+# SDC file used by BoomTile top level
+#
+
+set clk_period 1200
 set clk_name  clock
 set clk_port_name clock
 

--- a/constraints.sdc
+++ b/constraints.sdc
@@ -4,8 +4,8 @@ set sdc_version 2.0
 # SDC file used during SRAM abstract generation
 #
 
-# Run at 666 MHz
-set clk_period 1500
+# Run at 833 MHz
+set clk_period 1200
 
 # Covers all clock naming types in SRAMs and reg files
 set clock_ports [concat [get_ports -quiet *clk] [get_ports -quiet *clock]]


### PR DESCRIPTION
Sped up clock to 833 MHz.

Design metrics:
Design area: 787840 (prev: 784518)
Utilization: 35%: no change
tns: -128,422,560.00 (prev: -421,436,256.00)
wns: -1966.33 (prev: -5636.75) WNS is in reg2reg path
clock_skew: 122 (prev: 319)
CTS latency: 940 (prev: 1924)

clock tree still has one segment that's unbalanced, so no change but will investigate more:

![833MHz_ClockTree](https://github.com/user-attachments/assets/abed0f91-ec61-4f05-839b-0fdc46df4601)

Artifacts exist for this run, so CI should go quickly and anyone can pull down the artifacts. Artifact pulldown verified through clean workspace.