### PR TITLE
slack: add 'bazel run show_slack' that show slack in 3d

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -320,6 +320,24 @@ boom_regfile_rams = {
     for ram, io_constraint in boom_regfile_rams.items()
 ]
 
+orfs_run(
+    name = "slack",
+    src = ":BoomTile_cts",
+    outs = ["slack.txt"],
+    arguments = {
+        "OUTPUT": "$(location :slack.txt)",
+    },
+    script = ":slack-positions.tcl",
+)
+
+sh_binary(
+    name = "show_slack",
+    srcs = ["plot-3d-slack.py"],
+    args = ["$(location :slack)"],
+    data = ["slack"],
+    visibility = ["//visibility:public"],
+)
+
 boom_tile_macros = [x + "_generate_abstract" for x in all_srams.keys()]
 
 orfs_flow(

--- a/plot-3d-slack.py
+++ b/plot-3d-slack.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+import matplotlib.pyplot as plt
+import numpy as np
+from scipy.interpolate import griddata
+import sys
+
+
+def load_data(filename):
+    x = []
+    y = []
+    slack = []
+
+    with open(filename, "r") as file:
+        for line in file:
+            parts = line.split()
+            if len(parts) == 4:
+                slack.append(float(parts[1]))
+                x.append(float(parts[2]))
+                y.append(float(parts[3]))
+
+    return np.array(x), np.array(y), np.array(slack)
+
+
+def plot_3d(x, y, slack):
+    # Create grid data for surface plot
+    grid_x, grid_y = np.mgrid[min(x) : max(x) : 100j, min(y) : max(y) : 100j]
+    grid_z = griddata((x, y), slack, (grid_x, grid_y), method="cubic")
+
+    fig = plt.figure()
+    ax = fig.add_subplot(111, projection="3d")
+    surf = ax.plot_surface(grid_x, grid_y, grid_z, cmap="viridis")
+
+    ax.set_xlabel("X Position")
+    ax.set_ylabel("Y Position")
+    ax.set_zlabel("Slack")
+    fig.colorbar(surf, ax=ax, shrink=0.5, aspect=5)
+
+    plt.show()
+
+
+if __name__ == "__main__":
+    filename = sys.argv[1]
+    x, y, slack = load_data(filename)
+    plot_3d(x, y, slack)

--- a/slack-positions.tcl
+++ b/slack-positions.tcl
@@ -1,0 +1,28 @@
+source $::env(SCRIPTS_DIR)/load.tcl
+load_design 4_cts.odb 4_cts.sdc
+
+set paths [find_timing_paths -path_group reg2reg -sort_by_slack -group_count 1000]
+
+set db [::ord::get_db]
+set block [[$db getChip] getBlock]
+
+# open file
+set fp [open $::env(OUTPUT) w]
+foreach path $paths {
+  set endpoint [get_property $path endpoint]
+  set instance [$endpoint instance]
+  set name [get_property $endpoint full_name]
+  set slack [get_property $path slack]
+
+  # If DFF is in the $name and it ends with /D
+  if {[regexp {DFF} $name] && [regexp {/D$} $name]} {
+    # remove the /D suffix
+    set name [string range $name 0 end-2]
+    # replace [ and ] with \[ and \]
+    set name [string map { {[} {\[} {]} {\]} } $name]
+    set b [$block findInst $name]
+    set bbox [$b getBBox]
+    puts $fp "$name $slack [$bbox xMin] [$bbox yMin]"
+  }
+}
+close $fp


### PR DESCRIPTION
Run `bazel run show_slack`, and you get an interactive 3d graph of the slack as a function of position for the 1000 WNS paths.

@precisionmoon @maliberty @jeffng-or What I really wanted was CTS skew as a function of x/y position plotted in 3d.

This is based on some old ideas in this [discussion](https://github.com/The-OpenROAD-Project/OpenROAD/discussions/3788)

![image](https://github.com/user-attachments/assets/0ee3eb92-b891-431d-9898-ae6456fee3ad)
