### PR TITLE
enabled GPL_TIMING_DRIVEN

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -345,7 +345,7 @@ FAST_BUILD_SETTINGS = {
     "REMOVE_ABC_BUFFERS": "1",
     "TNS_END_PERCENT": "0",
     "SKIP_CTS_REPAIR_TIMING": "1",
-    "GPL_TIMING_DRIVEN": "0",
+    "GPL_TIMING_DRIVEN": "1",
     "GPL_ROUTABILITY_DRIVEN": "1",
     # Save global route time for now
     "SKIP_INCREMENTAL_REPAIR": "1",


### PR DESCRIPTION
Enable GPL_TIMING_DRIVEN. Here are some updated metrics:

- TNS (increase): -136,962,912.00 (v6 was -128,422,560.00)
- WNS (decrease): -1930.20 (v6 was -1966.33) - note that the WC path from v6 is now -1673)
- clock skew (decrease): 108.99 (v6 was 122)
- CTS latency (slight increase): 953 (v6 was 940) - clock tree still has long branch connecting to SRAM)

![wc_path](https://github.com/user-attachments/assets/7875e9d0-45bf-40e8-8882-0989c29e2ceb)

Still seeing "Routing congestion too high" error in GRT. Here's the heat map:

![routing_cong](https://github.com/user-attachments/assets/2e687503-7000-4210-b6ad-b995ef0a9139)

Artifacts exist in GCP through grt stage.