### PR TITLE
Flattened skinny SRAMs

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -112,8 +112,6 @@ all_source_files = sorted(glob(
     ]),
 ) + mock_files)
 
-# Haven't tried mocking any SRAMs with mock_area of None. Rest have been tried
-# with experiment notes on the same line
 boom_tile_small_srams = {
     "tag_array_64x184": {
         "mock_area": 0.62,
@@ -152,15 +150,6 @@ boom_tile_small_srams = {
         "mock_area": 0.32,
         "aspect_ratio": "1.2",
     },
-    "data_2048x8": {
-        "mock_area": 3.2,
-        "aspect_ratio": "58",
-        "core_utilization": "10",
-    },
-    "mem_256x4": {
-        "mock_area": 0.265,
-        "aspect_ratio": "36",
-    },  # close
 }
 
 boom_tile_rams = {


### PR DESCRIPTION
PR to flatten eight instances of "skinny" SRAMs. The good news is that grt is no longer reporting that the routing congestion is too high and there are no routing congestion DRCs reported in congestion.rpt (0 down from 8571). Here's the floorplan and the routing congestion view:

![routing_cong_drc](https://github.com/user-attachments/assets/4b00e708-aa05-4c3e-882f-c5ee5b81f00d)

The bad news is that all of the timing metrics went to pot (note that this run was not using gpl timing driven either):

TNS (increase): -472,802,016.00 (v6 was -128,422,560.00)
WNS (increases): -5815.44 (v6 was -1966.33) - note that the WC path from v6 is now -5396)
clock skew (increase): 308.54 (v6 was 122)
CTS latency (slight increase): 945 (v6 was 940) - clock tree still has long branch connecting to SRAM)

The WC path looks like:

![WC_path](https://github.com/user-attachments/assets/03dd9231-2697-48ae-8c6b-22f5c7961ba9)

So, @maliberty, please advise on how you want me to proceed with making this available to the development team.

@oharboe , please advise on whether you want to accept this PR since it fixes the routing congestion issues and I can proceed with trying to get the placement density up. Or whether you'd prefer to hold off.

Artifacts exist for this PR.
