### PR TITLE
sweep: sweep some optimizations

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -349,7 +349,6 @@ boom_tile_macros = [x + "_generate_abstract" for x in all_srams.keys()]
 
 FAST_BUILD_SETTINGS = {
     # repair_timing runs for hours in floorplan
-    "REMOVE_ABC_BUFFERS": "1",
     "TNS_END_PERCENT": "0",
     "SKIP_CTS_REPAIR_TIMING": "1",
     "GPL_TIMING_DRIVEN": "0",
@@ -364,48 +363,31 @@ SWEEP = {
     "base": {
     },
     "1": {
-        # Had to increase it to a minimum of 0.22 recommended
-        "PLACE_DENSITY": "0.24",
-        # Enable floorplan retiming
-        "REMOVE_ABC_BUFFERS": "0",
-        # Saves hours of build time
-        "SKIP_LAST_GASP": "1",
-        "SETUP_SLACK_MARGIN": "-1300",
+        "SKIP_CTS_REPAIR_TIMING": "0",
+        "GPL_TIMING_DRIVEN": "0",
+        "GPL_ROUTABILITY_DRIVEN": "1",
+        "SKIP_INCREMENTAL_REPAIR": "1",
     },
-    # "2": {
-    #     "PLACE_DENSITY": "0.21",
-    # },
-    # "3": {
-    #     "PLACE_DENSITY": "0.22",
-    # },
-    # "4": {
-    #     "PLACE_DENSITY": "0.23",
-    # },
-    # Too slow for now...
-    # "5": {
-    #     "REMOVE_ABC_BUFFERS": "0",
-    # },
-    # "6": {
-    #     "REMOVE_ABC_BUFFERS": "0",
-    #     "GPL_TIMING_DRIVEN": "1",
-    # },
-    # "7": {
-    #     "REMOVE_ABC_BUFFERS": "0",
-    #     "GPL_TIMING_DRIVEN": "1",
-    #     "SKIP_CTS_REPAIR_TIMING": "0",
-    # },
-    # "8": {
-    #     "REMOVE_ABC_BUFFERS": "0",
-    #     "GPL_TIMING_DRIVEN": "1",
-    #     "SKIP_CTS_REPAIR_TIMING": "0",
-    #     "SKIP_INCREMENTAL_REPAIR": "0",
-    # },
+    "2": {
+        "SKIP_CTS_REPAIR_TIMING": "0",
+        "GPL_TIMING_DRIVEN": "1",
+        "GPL_ROUTABILITY_DRIVEN": "1",
+        "SKIP_INCREMENTAL_REPAIR": "1",
+        "SETUP_SLACK_MARGIN": "-1200",
+    },
+    "3": {
+        "SKIP_CTS_REPAIR_TIMING": "0",
+        "GPL_TIMING_DRIVEN": "1",
+        "GPL_ROUTABILITY_DRIVEN": "1",
+        "SKIP_INCREMENTAL_REPAIR": "0",
+        "SETUP_SLACK_MARGIN": "-1000",
+    },
 }
 
 BOOMTILE_VARIABLES = SKIP_REPORT_METRICS | FAST_BUILD_SETTINGS | {
     "PDN_TCL": "$(PLATFORM_DIR)/openRoad/pdn/BLOCKS_grid_strategy.tcl",
     "IO_CONSTRAINTS": "$(location :io-boomtile)",
-    "PLACE_DENSITY": "0.20",
+    "PLACE_DENSITY": "0.24",
     # We only need hierarchical synthesis when we are running through floorplan
     # write_macro_placement macros.tcl
     "SYNTH_HIERARCHICAL": "1",
@@ -422,6 +404,10 @@ BOOMTILE_VARIABLES = SKIP_REPORT_METRICS | FAST_BUILD_SETTINGS | {
     "ROUTING_LAYER_ADJUSTMENT": "0.45",
     "DIE_AREA": "0 0 1500 1500",
     "CORE_AREA": "2 2 1498 1498",
+    # Saves hours of build time
+    "SKIP_LAST_GASP": "1",
+    "SETUP_SLACK_MARGIN": "-1300",
+    "HOLD_SLACK_MARGIN": "-200",
 }
 
 SWEEP_JSON = {


### PR DESCRIPTION
Stage: cts
| Variant                   | base        | 1            | 3            |
|---------------------------|-------------|--------------|--------------|
| crpr                      | 1.52        | 1.52         | 2.13         |
| skew                      | 113.21      | 113.21       | 139.94       |
| slack                     | -1553.49646 | -1553.906128 | -1565.608154 |
| tns                       | -80420496.0 | -80496816.0  | -78941104.0  |
| GPL_ROUTABILITY_DRIVEN    |             |              |              |
| GPL_TIMING_DRIVEN         |             |              | 1            |
| SETUP_SLACK_MARGIN        |             |              | -1000        |
| SKIP_CTS_REPAIR_TIMING    |             | 0            | 0            |
| SKIP_INCREMENTAL_REPAIR   |             |              | 0            |
| 2_1_floorplan.log         | 1227        | 1227         | 3726         |
| 2_2_floorplan_io.log      | 38          | 38           | 39           |
| 2_3_floorplan_tdms.log    | 0           | 0            | 0            |
| 2_4_floorplan_macro.log   | 1859        | 1860         | 1585         |
| 2_5_floorplan_tapcell.log | 38          | 38           | 39           |
| 2_6_floorplan_pdn.log     | 651         | 651          | 684          |
| 3_1_place_gp_skip_io.log  | 1034        | 985          | 979          |
| 3_2_place_iop.log         | 49          | 45           | 48           |
| 3_3_place_gp.log          | 2776        | 2746         | 10379        |
| 3_4_place_resized.log     | 655         | 620          | 636          |
| 3_5_place_dp.log          | 1602        | 1368         | 1503         |
| 4_1_cts.log               | 554         | 4413         | 3841         |

Base configuration variables
| Variable                 | Value                                                 |
|--------------------------|-------------------------------------------------------|
| CORE_AREA                | 2 2 1498 1498                                         |
| DIE_AREA                 | 0 0 1500 1500                                         |
| FILL_CELLS               |                                                       |
| GPL_ROUTABILITY_DRIVEN   | 1                                                     |
| GPL_TIMING_DRIVEN        | 0                                                     |
| HOLD_SLACK_MARGIN        | -200                                                  |
| IO_CONSTRAINTS           | $(location :io-boomtile)                              |
| MACRO_PLACE_HALO         | 19 19                                                 |
| MAX_ROUTING_LAYER        | M7                                                    |
| MIN_ROUTING_LAYER        | M2                                                    |
| PDN_TCL                  | $(PLATFORM_DIR)/openRoad/pdn/BLOCKS_grid_strategy.tcl |
| PLACE_DENSITY            | 0.24                                                  |
| PLACE_PINS_ARGS          | -annealing                                            |
| ROUTING_LAYER_ADJUSTMENT | 0.45                                                  |
| RTLMP_FLOW               | 1                                                     |
| SDC_FILE                 | $(location :constraints-boomtile)                     |
| SETUP_SLACK_MARGIN       | -1300                                                 |
| SKIP_CTS_REPAIR_TIMING   | 1                                                     |
| SKIP_INCREMENTAL_REPAIR  | 1                                                     |
| SKIP_LAST_GASP           | 1                                                     |
| SKIP_REPORT_METRICS      | 1                                                     |
| SYNTH_HIERARCHICAL       | 1                                                     |
| TAPCELL_TCL              |                                                       |
| TNS_END_PERCENT          | 0                                                     |
