### PR TITLE
report: use open.tcl which reads in timing properly

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -444,6 +444,13 @@ write_binary(
     verilog_files = all_source_files,
 ) for variant in SWEEP]
 
+[filegroup(
+    name = "BoomTile_" + variant + "_odb",
+    srcs = [":BoomTile_" + ("" if variant == "base" else variant + "_") + SWEEP_JSON["stage"]],
+    output_group = str(SWEEP_JSON["stages"].index(SWEEP_JSON["stage"]) + 2) + "_" + SWEEP_JSON["stage"] + ".odb",
+    visibility = [":__subpackages__"],
+) for variant in SWEEP]
+
 [orfs_run(
     name = "BoomTile_" + variant + "_report",
     src = ":BoomTile_" + ("" if variant == "base" else variant + "_") + SWEEP_JSON["stage"],
@@ -452,8 +459,9 @@ write_binary(
     ],
     arguments = {
         "OUTFILE": "$(location :BoomTile_" + variant + ".yaml)",
-        "REPORT_STAGE": SWEEP_JSON["stage"],
+        "ODB_FILE": "$(location :BoomTile_" + variant + "_odb)",
     },
+    data = [":BoomTile_" + variant + "_odb"],
     script = ":report-wns.tcl",
 ) for variant in SWEEP]
 

--- a/report-wns.tcl
+++ b/report-wns.tcl
@@ -1,28 +1,7 @@
 # Test this on some simple design in ORFS:
 #
-# REPORT_STAGE=place OUTFILE=blah.txt make run RUN_SCRIPT=~/megaboom/report-wns.tcl
-source $::env(SCRIPTS_DIR)/load.tcl
-switch -exact -- $::env(REPORT_STAGE) {
-  "floorplan" {
-    load_design 2_floorplan.odb 2_floorplan.sdc
-  }
-  "place" {
-    load_design 3_place.odb 3_place.sdc
-  }
-  "cts" {
-    load_design 4_cts.odb 4_cts.sdc
-  }
-  "grt" {
-    load_design 5_1_grt.odb 4_cts.sdc
-  }
-  "route" {
-    load_design 5_2_route.odb 4_cts.sdc
-  }
-  default {
-    puts "Unknown design: $::env(REPORT_STAGE)"
-    exit 1
-  }
-}
+# ODB_FILE=results/asap7/base/2_floorplan.odb OUTFILE=blah.txt make run RUN_SCRIPT=~/megaboom/report-wns.tcl
+source $::env(SCRIPTS_DIR)/open.tcl
 
 set paths [find_timing_paths -path_group reg2reg -sort_by_slack -group_count 1]
 set path [lindex $paths 0]


### PR DESCRIPTION
Waiting for variant 2, here is the table so far:

Stage: cts
| Variant                   | base         | 1            | 3            |
|---------------------------|--------------|--------------|--------------|
| crpr                      | 11.47        | 11.47        | 21.8         |
| skew                      | 362.76       | 362.76       | 351.29       |
| slack                     | -4490.124023 | -4380.438965 | -4755.364746 |
| tns                       | -381370656.0 | -374684800.0 | -376241280.0 |
| GPL_ROUTABILITY_DRIVEN    |              |              |              |
| GPL_TIMING_DRIVEN         |              |              | 1            |
| SETUP_SLACK_MARGIN        |              |              | -1000        |
| SKIP_CTS_REPAIR_TIMING    |              | 0            | 0            |
| SKIP_INCREMENTAL_REPAIR   |              |              | 0            |
| 2_1_floorplan.log         | 1227         | 1227         | 3726         |
| 2_2_floorplan_io.log      | 38           | 38           | 39           |
| 2_3_floorplan_tdms.log    | 0            | 0            | 0            |
| 2_4_floorplan_macro.log   | 1859         | 1860         | 1585         |
| 2_5_floorplan_tapcell.log | 38           | 38           | 39           |
| 2_6_floorplan_pdn.log     | 651          | 651          | 684          |
| 3_1_place_gp_skip_io.log  | 1034         | 985          | 979          |
| 3_2_place_iop.log         | 49           | 45           | 48           |
| 3_3_place_gp.log          | 2776         | 2746         | 10379        |
| 3_4_place_resized.log     | 655          | 620          | 636          |
| 3_5_place_dp.log          | 1602         | 1368         | 1503         |
| 4_1_cts.log               | 554          | 4413         | 3841         |

Base configuration variables
| Variable                 | Value                                                 |
|--------------------------|-------------------------------------------------------|
| CORE_AREA                | 2 2 1498 1498                                         |
| DIE_AREA                 | 0 0 1500 1500                                         |
| FILL_CELLS               |                                                       |
| GPL_ROUTABILITY_DRIVEN   | 1                                                     |
| GPL_TIMING_DRIVEN        | 0                                                     |
| HOLD_SLACK_MARGIN        | -200                                                  |
| IO_CONSTRAINTS           | $(location :io-boomtile)                              |
| MACRO_PLACE_HALO         | 19 19                                                 |
| MAX_ROUTING_LAYER        | M7                                                    |
| MIN_ROUTING_LAYER        | M2                                                    |
| PDN_TCL                  | $(PLATFORM_DIR)/openRoad/pdn/BLOCKS_grid_strategy.tcl |
| PLACE_DENSITY            | 0.24                                                  |
| PLACE_PINS_ARGS          | -annealing                                            |
| ROUTING_LAYER_ADJUSTMENT | 0.45                                                  |
| RTLMP_FLOW               | 1                                                     |
| SDC_FILE                 | $(location :constraints-boomtile)                     |
| SETUP_SLACK_MARGIN       | -1300                                                 |
| SKIP_CTS_REPAIR_TIMING   | 1                                                     |
| SKIP_INCREMENTAL_REPAIR  | 1                                                     |
| SKIP_LAST_GASP           | 1                                                     |
| SKIP_REPORT_METRICS      | 1                                                     |
| SYNTH_HIERARCHICAL       | 1                                                     |
| TAPCELL_TCL              |                                                       |
| TNS_END_PERCENT          | 0                                                     |
