### PR TITLE
wns_report: include dissolved macros line

### DIFF
--- a/wns_report.py
+++ b/wns_report.py
@@ -82,7 +82,9 @@ def main():
     logs = sorted(map(os.path.basename, pathlib.Path(log_dir).glob("*.log")))
     logs_dir = os.path.join(log_dir, "..")
 
-    variables = sorted(set(k for v in sweep.values() for k in v.get("variables", {}).keys()))
+    variables = sorted(
+        set(k for v in sweep.values() for k in v.get("variables", {}).keys())
+    )
 
     table_data = None
     for variant in sweep:
@@ -93,7 +95,7 @@ def main():
             stats = yaml.safe_load(file)
         names = sorted(stats.keys())
         if table_data is None:
-            table_data = [["Variant"] + names + variables + logs]
+            table_data = [["Variant"] + names + variables + ["dissolve"] + logs]
         table_data.append(
             (
                 [variant]
@@ -107,6 +109,7 @@ def main():
                     )
                     for variable in variables
                 ]
+                + [" ".join(sweep[variant].get("dissolve", []))]
                 + [
                     print_log_dir_times(os.path.join(logs_dir, variant, log))
                     for log in logs


### PR DESCRIPTION
Stage: cts
| Variant                   | base                          | 1            | 2                                 |
|---------------------------|-------------------------------|--------------|-----------------------------------|
| crpr                      | 15.04                         | 15.02        | 15.49                             |
| skew                      | 452.64                        | 583.52       | 575.04                            |
| slack                     | -4618.476074                  | -5494.812988 | -3262.439697                      |
| tns                       | -384685088.0                  | -451544224.0 | -97992368.0                       |
| MACRO_PLACEMENT_TCL       |                               |              | $(location write_macro_placement) |
| PLACE_DENSITY             |                               |              |                                   |
| REMOVE_ABC_BUFFERS        |                               | 0            |                                   |
| SETUP_SLACK_MARGIN        |                               |              |                                   |
| SKIP_LAST_GASP            |                               |              |                                   |
| SYNTH_HIERARCHICAL        |                               |              | 0                                 |
| dissolve                  | regfile_128x64 regfile_128x65 |              |                                   |
| 2_1_floorplan.log         | 1162                          | 1099         | 559                               |
| 2_2_floorplan_io.log      | 38                            | 38           | 20                                |
| 2_3_floorplan_tdms.log    | 0                             | 0            | 0                                 |
| 2_4_floorplan_macro.log   | 1609                          | 1742         | 23                                |
| 2_5_floorplan_tapcell.log | 39                            | 36           | 19                                |
| 2_6_floorplan_pdn.log     | 730                           | 915          | 894                               |
| 3_1_place_gp_skip_io.log  | 1969                          | 1694         | 2038                              |
| 3_2_place_iop.log         | 50                            | 50           | 28                                |
| 3_3_place_gp.log          | 4181                          | 6405         | 4020                              |
| 3_4_place_resized.log     | 641                           | 612          | 328                               |
| 3_5_place_dp.log          | 1635                          | 1512         | 821                               |
| 4_1_cts.log               | 557                           | 544          | 342                               |

Base configuration variables
| Variable                 | Value                                                 |
|--------------------------|-------------------------------------------------------|
| CORE_AREA                | 2 2 1998 1998                                         |
| DIE_AREA                 | 0 0 2000 2000                                         |
| FILL_CELLS               |                                                       |
| GPL_ROUTABILITY_DRIVEN   | 1                                                     |
| GPL_TIMING_DRIVEN        | 0                                                     |
| HOLD_SLACK_MARGIN        | -200                                                  |
| IO_CONSTRAINTS           | $(location :io-boomtile)                              |
| MACRO_PLACE_HALO         | 19 19                                                 |
| MAX_ROUTING_LAYER        | M7                                                    |
| MIN_ROUTING_LAYER        | M2                                                    |
| PDN_TCL                  | $(PLATFORM_DIR)/openRoad/pdn/BLOCKS_grid_strategy.tcl |
| PLACE_DENSITY            | 0.24                                                  |
| PLACE_PINS_ARGS          | -annealing                                            |
| ROUTING_LAYER_ADJUSTMENT | 0.45                                                  |
| RTLMP_FLOW               | 1                                                     |
| SDC_FILE                 | $(location :constraints-boomtile)                     |
| SETUP_SLACK_MARGIN       | -1300                                                 |
| SKIP_CTS_REPAIR_TIMING   | 1                                                     |
| SKIP_INCREMENTAL_REPAIR  | 1                                                     |
| SKIP_LAST_GASP           | 1                                                     |
| SKIP_REPORT_METRICS      | 1                                                     |
| SYNTH_HIERARCHICAL       | 1                                                     |
| TAPCELL_TCL              |                                                       |
| TNS_END_PERCENT          | 0                                                     |
