### PR TITLE
Macro placement flattened synthesis

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -360,13 +360,24 @@ SWEEP = {
             "floorplan": "BoomTile_synth",
         },
     },
+    "1": {
+        "description": "Flattend with automatic macro placement",
+        "variables": {
+            "SYNTH_HIERARCHICAL": "0",
+            # Macro placement fails with 0.24, tweak initial conditions
+            "PLACE_DENSITY": "0.25",
+        },
+    },
     "2": {
-        "description": "Same as base, but with flattend synthesis",
+        "description": "Macro placement as base, but with flattend synthesis",
         "variables": {
             "SYNTH_HIERARCHICAL": "0",
             "MACRO_PLACEMENT_TCL": "$(location write_macro_placement)",
         },
         "stage_sources": {"floorplan": ["write_macro_placement"]},
+        "previous_stage": {
+            "floorplan": "BoomTile_1_synth",
+        },
     },
     "3": {
         "description": "Same as base, only with CTS timing repair enabled",
@@ -410,6 +421,19 @@ SWEEP = {
             "place": "BoomTile_2_floorplan",
         },
         "stage_sources": {"floorplan": ["write_macro_placement"]},
+    },
+    "7": {
+        "description": "Flattend synthesis, CTS timing repair, timing driven placement and automatic macro placement",
+        "variables": {
+            "SYNTH_HIERARCHICAL": "0",
+            "SKIP_CTS_REPAIR_TIMING": "0",
+            "GPL_TIMING_DRIVEN": "1",
+            # Macro placement fails with 0.24, tweak initial conditions
+            "PLACE_DENSITY": "0.25",
+        },
+        "previous_stage": {
+            "place": "BoomTile_2_floorplan",
+        },
     },
 }
 


### PR DESCRIPTION
@maliberty @jeffng-or Trying flattend synthesis with automatic macro placement because flattening synthesis reduces number of instances with 50%.

Best WNS is variant 6:

![image](https://github.com/user-attachments/assets/f8a7143e-678a-4fec-96ff-ad44736f1187)


clock tree, skew is worst case on the order of 500ps overall, but the skew is 73 for the worst path, so an improved CTS won't move the needle on WNS.

![image](https://github.com/user-attachments/assets/9dcdb70d-c930-45a1-aedd-d2bb68cd6167)


Worst WNS routing has ca. 50% logic delay, logic depth 61, the rest is routing. 61 levels of logic. The documentation of BOOM clearly states that [the floating point unit must be register retimed](https://docs.boom-core.org/en/latest/sections/physical-realization.html)


![image](https://github.com/user-attachments/assets/cbba2581-1fdb-439c-a531-fb6a304aa9a3)


RUDY routing congestion; seems like it should be possible to make it pass grt.

![image](https://github.com/user-attachments/assets/33481bc1-4221-42b1-b595-d6b733129a88)


```
>>> report_checks -path_group reg2reg -fields {fanout slew}
Startpoint: dcache.s1_valid_REG_1$_SDFF_PP0_
            (rising edge-triggered flip-flop clocked by clock)
Endpoint: core.FpPipeline.fp_issue_unit.io_dis_uops_0_ready_REG$_DFF_P_
          (rising edge-triggered flip-flop clocked by clock)
Path Group: reg2reg
Path Type: max

Fanout    Slew   Delay    Time   Description
----------------------------------------------------------------------
                  0.00    0.00   clock clock (rise edge)
               1774.96 1774.96   clock network delay (propagated)
         15.90    0.00 1774.96 ^ dcache.s1_valid_REG_1$_SDFF_PP0_/CLK (DFFHQNx2_ASAP7_75t_R)
     2   56.43   62.64 1837.61 ^ dcache.s1_valid_REG_1$_SDFF_PP0_/QN (DFFHQNx2_ASAP7_75t_R)
     1   15.25   38.55 1876.16 ^ wire37774/Y (BUFx6f_ASAP7_75t_R)
     1   10.90   35.17 1911.33 ^ wire37773/Y (BUFx16f_ASAP7_75t_R)
     1   13.00   63.36 1974.68 ^ wire37772/Y (BUFx16f_ASAP7_75t_R)
     1   26.17   81.25 2055.94 ^ _1066848_/Y (AND5x2_ASAP7_75t_R)
     1   12.13   29.70 2085.64 ^ _1066849_/Y (AND4x1_ASAP7_75t_R)
     1   88.32   57.68 2143.31 ^ _1066852_/Y (AND4x2_ASAP7_75t_R)
     1   13.95   73.62 2216.94 ^ wire20216/Y (BUFx16f_ASAP7_75t_R)
     2   11.04   56.90 2273.83 ^ wire20215/Y (BUFx16f_ASAP7_75t_R)
     1   16.11   62.92 2336.75 ^ wire20214/Y (BUFx6f_ASAP7_75t_R)
     3   19.08   45.90 2382.66 ^ _1066853_/Y (AND3x2_ASAP7_75t_R)
     2   15.29   17.77 2400.43 ^ _1066854_/Y (AO21x1_ASAP7_75t_R)
     2   24.57   32.97 2433.40 ^ _1066885_/Y (AND5x2_ASAP7_75t_R)
     5   33.58   34.69 2468.09 ^ _1066886_/Y (AND2x6_ASAP7_75t_R)
     1   39.30   22.75 2490.84 v _1066887_/Y (NAND2x2_ASAP7_75t_R)
     4   10.49   36.71 2527.56 v wire8596/Y (BUFx16f_ASAP7_75t_R)
    10   10.14   31.88 2559.43 v _1066888_/Y (BUFx16f_ASAP7_75t_R)
     1   12.28   89.46 2648.89 v _1066892_/Y (OR2x2_ASAP7_75t_R)
     8   15.87   18.66 2667.55 v _1066893_/Y (BUFx6f_ASAP7_75t_R)
     1   20.81   13.85 2681.40 ^ _1066899_/Y (NOR2x1_ASAP7_75t_R)
     2   35.48   20.78 2702.18 v _1066900_/Y (AOI21x1_ASAP7_75t_R)
    10   17.50   25.08 2727.26 v _1093549_/Y (BUFx6f_ASAP7_75t_R)
    10   16.49   22.98 2750.24 v _1093550_/Y (BUFx10_ASAP7_75t_R)
    10   16.84   25.36 2775.60 v _1093551_/Y (BUFx6f_ASAP7_75t_R)
     4   12.22   17.98 2793.58 v _1093552_/Y (BUFx6f_ASAP7_75t_R)
     4   11.76   18.44 2812.02 v max_length6780/Y (BUFx16f_ASAP7_75t_R)
     4   87.93   50.38 2862.40 ^ _1975779_/CON (HAxp5_ASAP7_75t_R)
     1   23.37   19.05 2881.46 v _1975779_/SN (HAxp5_ASAP7_75t_R)
     2    8.11   18.86 2900.32 v rebuffer270/Y (BUFx3_ASAP7_75t_R)
     1   18.35   19.50 2919.82 v _1066967_/Y (XOR2x1_ASAP7_75t_R)
     1   14.81   33.84 2953.66 v _1066969_/Y (OR4x1_ASAP7_75t_R)
     1   34.90   51.42 3005.08 v _1066978_/Y (OR3x4_ASAP7_75t_R)
     2   14.21   44.97 3050.04 v wire4659/Y (BUFx6f_ASAP7_75t_R)
     8   32.56   55.93 3105.98 v _1067002_/Y (AND3x4_ASAP7_75t_R)
     2   13.83   29.44 3135.42 v _1067003_/Y (AND2x2_ASAP7_75t_R)
     3   14.70   18.46 3153.88 v _1067040_/Y (BUFx6f_ASAP7_75t_R)
     1   29.40   33.70 3187.57 v _1067041_/Y (AND3x4_ASAP7_75t_R)
     8    9.82   42.13 3229.71 v wire4000/Y (BUFx12f_ASAP7_75t_R)
     2    9.30   54.00 3283.71 v _1067042_/Y (AND2x4_ASAP7_75t_R)
     9   31.02   34.99 3318.70 v _1067043_/Y (XOR2x2_ASAP7_75t_R)
     4   12.03   21.89 3340.59 v _1067044_/Y (BUFx6f_ASAP7_75t_R)
     7    8.61   18.40 3358.99 v wire3600/Y (BUFx16f_ASAP7_75t_R)
    10   12.71   41.42 3400.41 v _1067045_/Y (BUFx16f_ASAP7_75t_R)
     3    9.45   23.33 3423.74 v _1067046_/Y (BUFx12f_ASAP7_75t_R)
     2   15.67   36.58 3460.32 v _1067047_/Y (AND3x1_ASAP7_75t_R)
     2   62.92   54.76 3515.08 v _1975801_/SN (HAxp5_ASAP7_75t_R)
     1   17.58   33.21 3548.29 v _1067059_/Y (XOR2x1_ASAP7_75t_R)
     1   11.63   32.56 3580.85 v _1067060_/Y (OR4x1_ASAP7_75t_R)
     1   37.99   52.18 3633.03 v _1067067_/Y (OR3x4_ASAP7_75t_R)
     2   40.49   83.12 3716.15 v _1067090_/Y (AND5x2_ASAP7_75t_R)
     3   28.53   51.46 3767.61 v _1067091_/Y (AND3x4_ASAP7_75t_R)
     2   13.70   21.83 3789.43 v _1067092_/Y (BUFx6f_ASAP7_75t_R)
     3    7.61   15.36 3804.79 v max_length2567/Y (BUFx12f_ASAP7_75t_R)
     8   36.48   75.36 3880.15 v _1067093_/Y (AND3x4_ASAP7_75t_R)
     5   47.49  104.32 3984.47 v _1067095_/Y (XNOR2x2_ASAP7_75t_R)
    20   14.85   30.62 4015.09 v _1067096_/Y (BUFx16f_ASAP7_75t_R)
     1   36.86   51.48 4066.57 ^ _1975803_/CON (HAxp5_ASAP7_75t_R)
     8   16.02   22.30 4088.86 ^ _1084515_/Y (BUFx6f_ASAP7_75t_R)
     4   13.33   12.03 4100.90 v _1185327_/Y (INVx2_ASAP7_75t_R)
     2   14.78   18.44 4119.33 v _1384446_/Y (AND3x1_ASAP7_75t_R)
     2   55.50   49.88 4169.21 v _1975807_/SN (HAxp5_ASAP7_75t_R)
     1   15.79   27.61 4196.82 v _1084521_/Y (XNOR2x1_ASAP7_75t_R)
     1   16.50   41.96 4238.77 v _1084523_/Y (OR5x1_ASAP7_75t_R)
     1  109.20   42.49 4281.27 ^ _1084544_/Y (OAI21x1_ASAP7_75t_R)
     1   12.35   54.86 4336.13 ^ wire1717/Y (BUFx16f_ASAP7_75t_R)
     1   20.48   38.21 4374.34 ^ _1084549_/Y (AO21x1_ASAP7_75t_R)
     9   11.14   19.51 4393.85 ^ _1084550_/Y (BUFx16f_ASAP7_75t_R)
     4   78.75   33.40 4427.25 v _1112139_/Y (NOR2x2_ASAP7_75t_R)
     2   76.28   67.52 4494.77 ^ _1112140_/Y (NAND2x2_ASAP7_75t_R)
     3   10.52   23.95 4518.72 ^ max_length1338/Y (BUFx12f_ASAP7_75t_R)
     1   13.99   51.20 4569.93 ^ _1112141_/Y (OR4x2_ASAP7_75t_R)
     8   13.94   18.65 4588.58 ^ _1112142_/Y (BUFx16f_ASAP7_75t_R)
     3   15.43   38.71 4627.29 ^ wire894/Y (BUFx6f_ASAP7_75t_R)
     6   25.63   33.88 4661.17 v _1112143_/Y (NAND2x2_ASAP7_75t_R)
    10   17.67   22.85 4684.03 v _1112144_/Y (BUFx4f_ASAP7_75t_R)
    10   13.75   21.85 4705.88 v _1112145_/Y (BUFx6f_ASAP7_75t_R)
     5   13.49   18.26 4724.14 v _1112146_/Y (BUFx6f_ASAP7_75t_R)
     7    9.37   23.55 4747.69 v wire612/Y (BUFx16f_ASAP7_75t_R)
     5   13.73   85.46 4833.15 v _1112147_/Y (BUFx12f_ASAP7_75t_R)
    10   13.69   20.53 4853.69 v _1112148_/Y (BUFx16f_ASAP7_75t_R)
     1   13.62   60.64 4914.33 v _1112149_/Y (AO21x2_ASAP7_75t_R)
     1   82.30   72.63 4986.96 v _1959551_/SN (FAx1_ASAP7_75t_R)
     1   59.21   45.49 5032.45 ^ _1959554_/CON (FAx1_ASAP7_75t_R)
     1   33.15   18.54 5050.98 v _1959554_/SN (FAx1_ASAP7_75t_R)
     1   18.16   14.88 5065.87 ^ _1922334_/Y (INVx1_ASAP7_75t_R)
     1   51.18   35.72 5101.59 v _1959562_/SN (FAx1_ASAP7_75t_R)
     1   21.95   17.97 5119.56 ^ _1922335_/Y (INVx1_ASAP7_75t_R)
     1   48.68   17.80 5137.36 v _1959568_/CON (FAx1_ASAP7_75t_R)
     1   60.47   21.21 5158.57 ^ _1959568_/SN (FAx1_ASAP7_75t_R)
     1   20.60   15.81 5174.37 v _1922337_/Y (INVx1_ASAP7_75t_R)
     1   67.88   30.47 5204.85 ^ _1959572_/CON (FAx1_ASAP7_75t_R)
     1   45.20   21.69 5226.53 v _1959572_/SN (FAx1_ASAP7_75t_R)
     1   20.71   17.05 5243.58 ^ _1922339_/Y (INVx1_ASAP7_75t_R)
     2   30.66   22.47 5266.05 v _1959573_/CON (FAx1_ASAP7_75t_R)
     1   39.17   20.08 5286.13 ^ _1959573_/SN (FAx1_ASAP7_75t_R)
     2   39.56   27.06 5313.19 v _1976622_/CON (HAxp5_ASAP7_75t_R)
     2   48.87   29.86 5343.05 ^ _1959574_/CON (FAx1_ASAP7_75t_R)
     1   11.33   27.31 5370.36 ^ _1112703_/Y (AND3x1_ASAP7_75t_R)
     1   10.47   13.34 5383.69 ^ _1112704_/Y (AO21x1_ASAP7_75t_R)
     4   25.44   40.83 5424.52 ^ _1112705_/Y (AND5x2_ASAP7_75t_R)
     1   21.09   28.60 5453.12 ^ _1112708_/Y (AND3x1_ASAP7_75t_R)
     1   17.02   13.31 5466.43 v _1112709_/Y (INVx1_ASAP7_75t_R)
         17.06    0.50 5466.93 v core.FpPipeline.fp_issue_unit.io_dis_uops_0_ready_REG$_DFF_P_/D (DFFHQNx2_ASAP7_75t_R)
                       5466.93   data arrival time

               1200.00 1200.00   clock clock (rise edge)
               1670.83 2870.83   clock network delay (propagated)
                 30.41 2901.23   clock reconvergence pessimism
                       2901.23 ^ core.FpPipeline.fp_issue_unit.io_dis_uops_0_ready_REG$_DFF_P_/CLK (DFFHQNx2_ASAP7_75t_R)
                 -1.89 2899.34   library setup time
                       2899.34   data required time
----------------------------------------------------------------------
                       2899.34   data required time
                       -5466.93   data arrival time
----------------------------------------------------------------------
                       -2567.59   slack (VIOLATED)
```


Stage: cts
| Variant                        | base         | 1                                       | 2                                                    | 3                                                 | 4                                         | 5                                                               | 6                                                                                           | 7                                                                                            |
|--------------------------------|--------------|-----------------------------------------|------------------------------------------------------|---------------------------------------------------|-------------------------------------------|-----------------------------------------------------------------|---------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------|
| Description                    |              | Flattend with automatic macro placement | Macro placement as base, but with flattend synthesis | Same as base, only with CTS timing repair enabled | Same as base, but timing driven placement | Same as base, but with flattend synthesis and CTS timing repair | Same as base, but with flattend synthesis and CTS timing repair and timing driven placement | Flattend synthesis, CTS timing repair, timing driven placement and automatic macro placement |
| Buffer                         | 264492       | 119157                                  | 119157                                               | 264492                                            | 264492                                    | 119154                                                          | 119150                                                                                      | 119153                                                                                       |
| Clock buffer                   | 23052        | 11915                                   | 12067                                                | 23052                                             | 23218                                     | 12067                                                           | 12110                                                                                       | 11948                                                                                        |
| Clock inverter                 | 6997         | 3667                                    | 3634                                                 | 6997                                              | 6911                                      | 3634                                                            | 3693                                                                                        | 3705                                                                                         |
| Inverter                       | 141051       | 62571                                   | 62571                                                | 141051                                            | 141051                                    | 62571                                                           | 62571                                                                                       | 62571                                                                                        |
| Macro                          | 72           | 72                                      | 72                                                   | 72                                                | 72                                        | 72                                                              | 72                                                                                          | 72                                                                                           |
| Multi-Input combinational cell | 1365515      | 745216                                  | 745216                                               | 1365515                                           | 1365515                                   | 745218                                                          | 745218                                                                                      | 745218                                                                                       |
| Sequential cell                | 239698       | 118443                                  | 118443                                               | 239698                                            | 239698                                    | 118443                                                          | 118443                                                                                      | 118443                                                                                       |
| Tie cell                       | 2578         | 60                                      | 60                                                   | 2578                                              | 2578                                      | 60                                                              | 60                                                                                          | 60                                                                                           |
| Timing Repair Buffer           | 88407        | 43381                                   | 43364                                                | 91733                                             | 88691                                     | 46595                                                           | 47315                                                                                       | 45956                                                                                        |
| Total                          | 2131862      | 1104482                                 | 1104584                                              | 2135188                                           | 2132226                                   | 1107814                                                         | 1108632                                                                                     | 1107126                                                                                      |
| slack                          | -5494.812988 | -3077.346924                            | -3262.439697                                         | -5307.493652                                      | -4943.15625                               | -2857.862305                                                    | -2567.585693                                                                                | -2646.537109                                                                                 |
| GPL_TIMING_DRIVEN              |              |                                         |                                                      |                                                   | 1                                         |                                                                 | 1                                                                                           | 1                                                                                            |
| MACRO_PLACEMENT_TCL            |              |                                         | $(location write_macro_placement)                    |                                                   |                                           | $(location write_macro_placement)                               | $(location write_macro_placement)                                                           |                                                                                              |
| PLACE_DENSITY                  |              | 0.25                                    |                                                      |                                                   |                                           |                                                                 |                                                                                             | 0.25                                                                                         |
| SKIP_CTS_REPAIR_TIMING         |              |                                         |                                                      | 0                                                 |                                           | 0                                                               | 0                                                                                           | 0                                                                                            |
| SYNTH_HIERARCHICAL             |              | 0                                       | 0                                                    |                                                   |                                           | 0                                                               | 0                                                                                           | 0                                                                                            |
| dissolve                       |              |                                         |                                                      |                                                   |                                           |                                                                 |                                                                                             |                                                                                              |
| previous_stage                 |              |                                         | floorplan: BoomTile_1_synth                          | cts: BoomTile_place                               | place: BoomTile_floorplan                 | cts: BoomTile_2_place                                           | place: BoomTile_2_floorplan                                                                 | place: BoomTile_2_floorplan                                                                  |
| 2_1_floorplan.log              | 1146         | 548                                     | 544                                                  | N/A                                               | N/A                                       | N/A                                                             | N/A                                                                                         | N/A                                                                                          |
| 2_2_floorplan_io.log           | 37           | 19                                      | 19                                                   | N/A                                               | N/A                                       | N/A                                                             | N/A                                                                                         | N/A                                                                                          |
| 2_3_floorplan_macro.log        | 1519         | 2695                                    | 21                                                   | N/A                                               | N/A                                       | N/A                                                             | N/A                                                                                         | N/A                                                                                          |
| 2_4_floorplan_tapcell.log      | 35           | 19                                      | 18                                                   | N/A                                               | N/A                                       | N/A                                                             | N/A                                                                                         | N/A                                                                                          |
| 2_5_floorplan_pdn.log          | 895          | 881                                     | 858                                                  | N/A                                               | N/A                                       | N/A                                                             | N/A                                                                                         | N/A                                                                                          |
| 3_1_place_gp_skip_io.log       | 1648         | 1817                                    | 1954                                                 | N/A                                               | 1355                                      | N/A                                                             | 1824                                                                                        | 1971                                                                                         |
| 3_2_place_iop.log              | 49           | 28                                      | 28                                                   | N/A                                               | 40                                        | N/A                                                             | 27                                                                                          | 28                                                                                           |
| 3_3_place_gp.log               | 6129         | 4562                                    | 3907                                                 | N/A                                               | 11084                                     | N/A                                                             | 7092                                                                                        | 7923                                                                                         |
| 3_4_place_resized.log          | 604          | 319                                     | 328                                                  | N/A                                               | 553                                       | N/A                                                             | 315                                                                                         | 320                                                                                          |
| 3_5_place_dp.log               | 1447         | 818                                     | 892                                                  | N/A                                               | 1090                                      | N/A                                                             | 824                                                                                         | 839                                                                                          |
| 4_1_cts.log                    | 543          | 306                                     | 307                                                  | 6293                                              | 545                                       | 2754                                                            | 2935                                                                                        | 2641                                                                                         |

Base configuration variables
| Variable                 | Value                                                 |
|--------------------------|-------------------------------------------------------|
| CORE_AREA                | 2 2 1998 1998                                         |
| DIE_AREA                 | 0 0 2000 2000                                         |
| FILL_CELLS               |                                                       |
| GPL_ROUTABILITY_DRIVEN   | 1                                                     |
| GPL_TIMING_DRIVEN        | 0                                                     |
| HOLD_SLACK_MARGIN        | -200                                                  |
| IO_CONSTRAINTS           | $(location :io-boomtile)                              |
| MACRO_PLACE_HALO         | 19 19                                                 |
| MAX_ROUTING_LAYER        | M7                                                    |
| MIN_ROUTING_LAYER        | M2                                                    |
| PDN_TCL                  | $(PLATFORM_DIR)/openRoad/pdn/BLOCKS_grid_strategy.tcl |
| PLACE_DENSITY            | 0.24                                                  |
| PLACE_PINS_ARGS          | -annealing                                            |
| ROUTING_LAYER_ADJUSTMENT | 0.45                                                  |
| SDC_FILE                 | $(location :constraints-boomtile)                     |
| SETUP_SLACK_MARGIN       | -1300                                                 |
| SKIP_CTS_REPAIR_TIMING   | 1                                                     |
| SKIP_INCREMENTAL_REPAIR  | 1                                                     |
| SKIP_LAST_GASP           | 1                                                     |
| SKIP_REPORT_METRICS      | 1                                                     |
| SYNTH_HIERARCHICAL       | 1                                                     |
| TAPCELL_TCL              |                                                       |
| TNS_END_PERCENT          | 0                                                     |