### PR TITLE
variants: GPL_TIMING_DRIVEN=1

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -377,6 +377,15 @@ SWEEP = {
             "cts": "BoomTile_place",
         },
     },
+    "4": {
+        "description": "Same as base, but timing driven placement",
+        "variables": {
+            "GPL_TIMING_DRIVEN": "1",
+        },
+        "previous_stage": {
+            "place": "BoomTile_floorplan",
+        },
+    },
 }
 
 BOOMTILE_VARIABLES = SKIP_REPORT_METRICS | FAST_BUILD_SETTINGS | {


### PR DESCRIPTION
Stage: cts
| Variant                        | base         | 2                                         | 3                                                 | 4                                         |
|--------------------------------|--------------|-------------------------------------------|---------------------------------------------------|-------------------------------------------|
| Description                    |              | Same as base, but with flattend synthesis | Same as base, only with CTS timing repair enabled | Same as base, but timing driven placement |
| Buffer                         | 264492       | 119157                                    | 264492                                            | 264492                                    |
| Clock buffer                   | 23052        | 12067                                     | 23052                                             | 23218                                     |
| Clock inverter                 | 6997         | 3634                                      | 6997                                              | 6911                                      |
| Inverter                       | 141051       | 62571                                     | 141051                                            | 141051                                    |
| Macro                          | 72           | 72                                        | 72                                                | 72                                        |
| Multi-Input combinational cell | 1365515      | 745216                                    | 1365515                                           | 1365515                                   |
| Sequential cell                | 239698       | 118443                                    | 239698                                            | 239698                                    |
| Tie cell                       | 2578         | 60                                        | 2578                                              | 2578                                      |
| Timing Repair Buffer           | 88407        | 43364                                     | 91733                                             | 88691                                     |
| Total                          | 2131862      | 1104584                                   | 2135188                                           | 2132226                                   |
| slack                          | -5494.812988 | -3262.439697                              | -5307.493652                                      | -4943.15625                               |
| GPL_TIMING_DRIVEN              |              |                                           |                                                   | 1                                         |
| MACRO_PLACEMENT_TCL            |              | $(location write_macro_placement)         |                                                   |                                           |
| SKIP_CTS_REPAIR_TIMING         |              |                                           | 0                                                 |                                           |
| SYNTH_HIERARCHICAL             |              | 0                                         |                                                   |                                           |
| dissolve                       |              |                                           |                                                   |                                           |
| previous_stage                 |              |                                           | cts: BoomTile_place                               | place: BoomTile_floorplan                 |
| 2_1_floorplan.log              | 1146         | 566                                       | N/A                                               | N/A                                       |
| 2_2_floorplan_io.log           | 37           | 20                                        | N/A                                               | N/A                                       |
| 2_3_floorplan_macro.log        | 1519         | 22                                        | N/A                                               | N/A                                       |
| 2_4_floorplan_tapcell.log      | 35           | 18                                        | N/A                                               | N/A                                       |
| 2_5_floorplan_pdn.log          | 895          | 874                                       | N/A                                               | N/A                                       |
| 3_1_place_gp_skip_io.log       | 1648         | 1954                                      | N/A                                               | 1355                                      |
| 3_2_place_iop.log              | 49           | 28                                        | N/A                                               | 40                                        |
| 3_3_place_gp.log               | 6129         | 3907                                      | N/A                                               | 11084                                     |
| 3_4_place_resized.log          | 604          | 328                                       | N/A                                               | 553                                       |
| 3_5_place_dp.log               | 1447         | 892                                       | N/A                                               | 1090                                      |
| 4_1_cts.log                    | 543          | 307                                       | 6293                                              | 545                                       |

Base configuration variables
| Variable                 | Value                                                 |
|--------------------------|-------------------------------------------------------|
| CORE_AREA                | 2 2 1998 1998                                         |
| DIE_AREA                 | 0 0 2000 2000                                         |
| FILL_CELLS               |                                                       |
| GPL_ROUTABILITY_DRIVEN   | 1                                                     |
| GPL_TIMING_DRIVEN        | 0                                                     |
| HOLD_SLACK_MARGIN        | -200                                                  |
| IO_CONSTRAINTS           | $(location :io-boomtile)                              |
| MACRO_PLACE_HALO         | 19 19                                                 |
| MAX_ROUTING_LAYER        | M7                                                    |
| MIN_ROUTING_LAYER        | M2                                                    |
| PDN_TCL                  | $(PLATFORM_DIR)/openRoad/pdn/BLOCKS_grid_strategy.tcl |
| PLACE_DENSITY            | 0.24                                                  |
| PLACE_PINS_ARGS          | -annealing                                            |
| ROUTING_LAYER_ADJUSTMENT | 0.45                                                  |
| SDC_FILE                 | $(location :constraints-boomtile)                     |
| SETUP_SLACK_MARGIN       | -1300                                                 |
| SKIP_CTS_REPAIR_TIMING   | 1                                                     |
| SKIP_INCREMENTAL_REPAIR  | 1                                                     |
| SKIP_LAST_GASP           | 1                                                     |
| SKIP_REPORT_METRICS      | 1                                                     |
| SYNTH_HIERARCHICAL       | 1                                                     |
| TAPCELL_TCL              |                                                       |
| TNS_END_PERCENT          | 0                                                     |
