### PR TITLE
variants: try different MAX_UNGROUP_SIZEs

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -435,7 +435,11 @@ SWEEP = {
             "place": "BoomTile_2_floorplan",
         },
     },
-}
+} | {str(i + 8): {
+    "variables": {
+        "MAX_UNGROUP_SIZE": str((1 << i) * 200),
+    },
+} for i in range(0, 11)}
 
 BOOMTILE_VARIABLES = SKIP_REPORT_METRICS | FAST_BUILD_SETTINGS | {
     "PDN_TCL": "$(PLATFORM_DIR)/openRoad/pdn/BLOCKS_grid_strategy.tcl",


### PR DESCRIPTION
Macro placement did not complete all the runs, but so far this seems pretty conclusive.

The best thing is to:

1. create a macro placement based upon hierarchical design
2. use that macro placement, but use flattened synthesis


![image](https://github.com/user-attachments/assets/0a9d8864-61d6-4555-861c-e783f69aa81d)



Stage: cts
| Variant                        | base         | 1                                       | 2                                                    | 3                                                 | 4                                         | 5                                                               | 6                                                                                           | 7                                                                                            | 8            | 9        | 10           | 12           | 14           | 18           |
|--------------------------------|--------------|-----------------------------------------|------------------------------------------------------|---------------------------------------------------|-------------------------------------------|-----------------------------------------------------------------|---------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------|--------------|----------|--------------|--------------|--------------|--------------|
| Description                    |              | Flattend with automatic macro placement | Macro placement as base, but with flattend synthesis | Same as base, only with CTS timing repair enabled | Same as base, but timing driven placement | Same as base, but with flattend synthesis and CTS timing repair | Same as base, but with flattend synthesis and CTS timing repair and timing driven placement | Flattend synthesis, CTS timing repair, timing driven placement and automatic macro placement |              |          |              |              |              |              |
| Buffer                         | 264492       | 119157                                  | 119157                                               | 264492                                            | 264492                                    | 119154                                                          | 119150                                                                                      | 119153                                                                                       | 263091       | 234448   | 234934       | 230038       | 221693       | 123692       |
| Clock buffer                   | 23052        | 11915                                   | 12067                                                | 23052                                             | 23218                                     | 12067                                                           | 12110                                                                                       | 11948                                                                                        | 22970        | 23496    | 23203        | 23022        | 21374        | 13094        |
| Clock inverter                 | 6997         | 3667                                    | 3634                                                 | 6997                                              | 6911                                      | 3634                                                            | 3693                                                                                        | 3705                                                                                         | 7150         | 7109     | 7024         | 6783         | 6694         | 3712         |
| Inverter                       | 141051       | 62571                                   | 62571                                                | 141051                                            | 141051                                    | 62571                                                           | 62571                                                                                       | 62571                                                                                        | 141091       | 109881   | 104231       | 101426       | 91747        | 67962        |
| Macro                          | 72           | 72                                      | 72                                                   | 72                                                | 72                                        | 72                                                              | 72                                                                                          | 72                                                                                           | 72           | 72       | 72           | 72           | 72           | 72           |
| Multi-Input combinational cell | 1365515      | 745216                                  | 745216                                               | 1365515                                           | 1365515                                   | 745218                                                          | 745218                                                                                      | 745218                                                                                       | 1361907      | 1353937  | 1365706      | 1338552      | 1307735      | 759487       |
| Sequential cell                | 239698       | 118443                                  | 118443                                               | 239698                                            | 239698                                    | 118443                                                          | 118443                                                                                      | 118443                                                                                       | 239521       | 238821   | 237670       | 233024       | 222744       | 121192       |
| Tie cell                       | 2578         | 60                                      | 60                                                   | 2578                                              | 2578                                      | 60                                                              | 60                                                                                          | 60                                                                                           | 2310         | 2194     | 2228         | 1833         | 3658         | 102          |
| Timing Repair Buffer           | 88407        | 43381                                   | 43364                                                | 91733                                             | 88691                                     | 46595                                                           | 47315                                                                                       | 45956                                                                                        | 93788        | 94526    | 90982        | 86708        | 89999        | 53761        |
| Total                          | 2131862      | 1104482                                 | 1104584                                              | 2135188                                           | 2132226                                   | 1107814                                                         | 1108632                                                                                     | 1107126                                                                                      | 2131900      | 2064484  | 2066050      | 2021458      | 1965716      | 1143074      |
| slack                          | -5494.812988 | -3077.346924                            | -3262.439697                                         | -5307.493652                                      | -4943.15625                               | -2857.862305                                                    | -2567.585693                                                                                | -2646.537109                                                                                 | -4807.877441 | -5851.25 | -4858.518066 | -5792.476562 | -5357.462891 | -4398.755859 |
| GPL_TIMING_DRIVEN              |              |                                         |                                                      |                                                   | 1                                         |                                                                 | 1                                                                                           | 1                                                                                            |              |          |              |              |              |              |
| MACRO_PLACEMENT_TCL            |              |                                         | $(location write_macro_placement)                    |                                                   |                                           | $(location write_macro_placement)                               | $(location write_macro_placement)                                                           |                                                                                              |              |          |              |              |              |              |
| MAX_UNGROUP_SIZE               |              |                                         |                                                      |                                                   |                                           |                                                                 |                                                                                             |                                                                                              | 200          | 400      | 800          | 3200         | 12800        | 204800       |
| PLACE_DENSITY                  |              | 0.25                                    |                                                      |                                                   |                                           |                                                                 |                                                                                             | 0.25                                                                                         |              |          |              |              |              |              |
| SKIP_CTS_REPAIR_TIMING         |              |                                         |                                                      | 0                                                 |                                           | 0                                                               | 0                                                                                           | 0                                                                                            |              |          |              |              |              |              |
| SYNTH_HIERARCHICAL             |              | 0                                       | 0                                                    |                                                   |                                           | 0                                                               | 0                                                                                           | 0                                                                                            |              |          |              |              |              |              |
| dissolve                       |              |                                         |                                                      |                                                   |                                           |                                                                 |                                                                                             |                                                                                              |              |          |              |              |              |              |
| previous_stage                 |              |                                         | floorplan: BoomTile_1_synth                          | cts: BoomTile_place                               | place: BoomTile_floorplan                 | cts: BoomTile_2_place                                           | place: BoomTile_2_floorplan                                                                 | place: BoomTile_2_floorplan                                                                  |              |          |              |              |              |              |
| 2_1_floorplan.log              | 1146         | 548                                     | 544                                                  | N/A                                               | N/A                                       | N/A                                                             | N/A                                                                                         | N/A                                                                                          | 897          | 2861     | 2724         | 2569         | 1983         | 744          |
| 2_2_floorplan_io.log           | 37           | 19                                      | 19                                                   | N/A                                               | N/A                                       | N/A                                                             | N/A                                                                                         | N/A                                                                                          | 40           | 53       | 53           | 48           | 56           | 23           |
| 2_3_floorplan_macro.log        | 1519         | 2695                                    | 21                                                   | N/A                                               | N/A                                       | N/A                                                             | N/A                                                                                         | N/A                                                                                          | 1483         | 11896    | 12404        | 2569         | 21882        | 8491         |
| 2_4_floorplan_tapcell.log      | 35           | 19                                      | 18                                                   | N/A                                               | N/A                                       | N/A                                                             | N/A                                                                                         | N/A                                                                                          | 37           | 44       | 99           | 45           | 39           | 25           |
| 2_5_floorplan_pdn.log          | 895          | 881                                     | 858                                                  | N/A                                               | N/A                                       | N/A                                                             | N/A                                                                                         | N/A                                                                                          | 908          | 1341     | 11932        | 1388         | 1085         | 1463         |
| 3_1_place_gp_skip_io.log       | 1648         | 1817                                    | 1954                                                 | N/A                                               | 1355                                      | N/A                                                             | 1824                                                                                        | 1971                                                                                         | 2041         | 1737     | 1901         | 2196         | 1909         | 2018         |
| 3_2_place_iop.log              | 49           | 28                                      | 28                                                   | N/A                                               | 40                                        | N/A                                                             | 27                                                                                          | 28                                                                                           | 79           | 56       | 57           | 68           | 52           | 45           |
| 3_3_place_gp.log               | 6129         | 4562                                    | 3907                                                 | N/A                                               | 11084                                     | N/A                                                             | 7092                                                                                        | 7923                                                                                         | 9433         | 9406     | 4955         | 5564         | 5895         | 7811         |
| 3_4_place_resized.log          | 604          | 319                                     | 328                                                  | N/A                                               | 553                                       | N/A                                                             | 315                                                                                         | 320                                                                                          | 1670         | 803      | 667          | 2092         | 666          | 467          |
| 3_5_place_dp.log               | 1447         | 818                                     | 892                                                  | N/A                                               | 1090                                      | N/A                                                             | 824                                                                                         | 839                                                                                          | 6495         | 2362     | 2934         | 5762         | 2063         | 5482         |
| 4_1_cts.log                    | 543          | 306                                     | 307                                                  | 6293                                              | 545                                       | 2754                                                            | 2935                                                                                        | 2641                                                                                         | 1815         | 850      | 550          | 1554         | 1348         | 1461         |

Base configuration variables
| Variable                 | Value                                                 |
|--------------------------|-------------------------------------------------------|
| CORE_AREA                | 2 2 1998 1998                                         |
| DIE_AREA                 | 0 0 2000 2000                                         |
| FILL_CELLS               |                                                       |
| GPL_ROUTABILITY_DRIVEN   | 1                                                     |
| GPL_TIMING_DRIVEN        | 0                                                     |
| HOLD_SLACK_MARGIN        | -200                                                  |
| IO_CONSTRAINTS           | $(location :io-boomtile)                              |
| MACRO_PLACE_HALO         | 19 19                                                 |
| MAX_ROUTING_LAYER        | M7                                                    |
| MIN_ROUTING_LAYER        | M2                                                    |
| PDN_TCL                  | $(PLATFORM_DIR)/openRoad/pdn/BLOCKS_grid_strategy.tcl |
| PLACE_DENSITY            | 0.24                                                  |
| PLACE_PINS_ARGS          | -annealing                                            |
| ROUTING_LAYER_ADJUSTMENT | 0.45                                                  |
| SDC_FILE                 | $(location :constraints-boomtile)                     |
| SETUP_SLACK_MARGIN       | -1300                                                 |
| SKIP_CTS_REPAIR_TIMING   | 1                                                     |
| SKIP_INCREMENTAL_REPAIR  | 1                                                     |
| SKIP_LAST_GASP           | 1                                                     |
| SKIP_REPORT_METRICS      | 1                                                     |
| SYNTH_HIERARCHICAL       | 1                                                     |
| TAPCELL_TCL              |                                                       |
| TNS_END_PERCENT          | 0                                                     |
