### PR TITLE
ci: support building grt in sweeps

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -486,6 +486,13 @@ ALL_VARIANTS = SWEEP | OTHER_VARIANTS
     visibility = [":__subpackages__"],
 ) for variant in SWEEP]
 
+# This can be built in parallel, but grt needs to be build in serial
+filegroup(
+    name = "sweep_parallel",
+    srcs = ["BoomTile_" + ("" if variant == "base" else variant + "_") + "cts" for variant in SWEEP],
+    visibility = ["//visibility:public"],
+)
+
 genrule(
     name = "wns_report",
     srcs = [

--- a/etc/BuildMegaboom.sh
+++ b/etc/BuildMegaboom.sh
@@ -8,5 +8,10 @@ exec 2>&1
 # Check GCP service account entitlements first
 test/cred_helper_test.py
 
-bazel build wns_report BoomTile_grt --keep_going
+bazel build sweep_parallel --keep_going
+# If we're not sweeping grt, then we could have
+# started wns_report sooner, but at least we're not
+# running multiple grt builds in parallel, which makes
+# the server fall over.
+bazel build --jobs 1 wns_report BoomTile_grt --keep_going
 cat bazel-bin/BoomTile_wns_report.md


### PR DESCRIPTION
@jeffng-or FYI, add a sweep_parallel filegroup to build stuff in parallel and then afterwards build grt in serial