### PR TITLE
macro: automatic placement with flattened synthesis

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -377,6 +377,15 @@ SWEEP = {
         },
         "stage_sources": {"floorplan": ["write_macro_placement"]},
     },
+    "1": {
+        "description": "Flattend, automatic macro placement",
+        "variables": {
+            "SYNTH_HIERARCHICAL": "0",
+            "GPL_TIMING_DRIVEN": "1",
+            "SKIP_CTS_REPAIR_TIMING": "0",
+            "SKIP_LAST_GASP": "0",
+        }
+    },
 }
 
 BOOMTILE_VARIABLES = SKIP_REPORT_METRICS | FAST_BUILD_SETTINGS | {


### PR DESCRIPTION
If I'm to use flattened synthesis with macro placement from hierarchical synthesis, then sweeping die area values becomes tedious.

Let us see how bad macro placement is with flattened synthesis.