### PR TITLE
megaboom: reduce floorplan to 1500x1500

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -392,8 +392,8 @@ BOOMTILE_VARIABLES = SKIP_REPORT_METRICS | FAST_BUILD_SETTINGS | {
     "MIN_ROUTING_LAYER": "M2",
     "MAX_ROUTING_LAYER": "M7",
     "ROUTING_LAYER_ADJUSTMENT": "0.45",
-    "DIE_AREA": "0 0 2000 2000",
-    "CORE_AREA": "2 2 1998 1998",
+    "DIE_AREA": "0 0 1500 1500",
+    "CORE_AREA": "2 2 1498 1498",
     # Saves hours of build time, specific to BoomTile
     "SKIP_LAST_GASP": "1",
     "SETUP_SLACK_MARGIN": "-1300",


### PR DESCRIPTION
This route seems to be looping around the register file:

![image](https://github.com/user-attachments/assets/9ead798a-e4bb-4121-b7d5-5a30b747e5f1)

WNS regressed from -3300 to -6500, but it looks like there's some pathology in routing that is causing the jump from -3300 to -6500 by clicking on the buckets between -3300 to -6500, they all look sort of like this:

![image](https://github.com/user-attachments/assets/4c5f16d4-2cc9-457f-ae20-a8f3c9685ced)

