### PR TITLE
bazel-orfs: bump

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -15,7 +15,7 @@ module(
 bazel_dep(name = "bazel-orfs")
 git_override(
     module_name = "bazel-orfs",
-    commit = "b141f4942eb8b457e9d37d6ae575abf8dcae8b39",
+    commit = "994975a0a850f85890c3b30b78285cb72d8b5315",
     remote = "https://github.com/The-OpenROAD-Project/bazel-orfs.git",
 )
 


### PR DESCRIPTION
New floorplan. At some point I just increased to 2000x2000um when I had the wrong sizes of macros, now we see that the floorplan should be reduced to 1500x1500 or less.

![image](https://github.com/user-attachments/assets/c576ecb8-7851-40e4-a61b-97b7e7cf795d)

Stage: cts
| Variant                        | base                              |
|--------------------------------|-----------------------------------|
| Description                    | Flattend, timing driven placement |
| Buffer                         | 118586                            |
| Clock buffer                   | 12894                             |
| Clock inverter                 | 3737                              |
| Inverter                       | 70385                             |
| Macro                          | 72                                |
| Multi-Input combinational cell | 740179                            |
| Sequential cell                | 118443                            |
| Tie cell                       | 60                                |
| Timing Repair Buffer           | 48326                             |
| Total                          | 1112682                           |
| slack                          | -2872.979248                      |
| tns                            | -95525616.0                       |
| GPL_TIMING_DRIVEN              | 1                                 |
| MACRO_PLACEMENT_TCL            | $(location write_macro_placement) |
| SKIP_CTS_REPAIR_TIMING         | 0                                 |
| SKIP_LAST_GASP                 | 0                                 |
| SYNTH_HIERARCHICAL             | 0                                 |
| dissolve                       |                                   |
| previous_stage                 |                                   |
| 2_1_floorplan.log              | 134                               |
| 2_2_floorplan_io.log           | 20                                |
| 2_3_floorplan_macro.log        | 22                                |
| 2_4_floorplan_tapcell.log      | 18                                |
| 2_5_floorplan_pdn.log          | 727                               |
| 3_1_place_gp_skip_io.log       | 2224                              |
| 3_2_place_iop.log              | 28                                |
| 3_3_place_gp.log               | 13303                             |
| 3_4_place_resized.log          | 310                               |
| 3_5_place_dp.log               | 840                               |
| 4_1_cts.log                    | 1801                              |

Base configuration variables
| Variable                 | Value                                                 |
|--------------------------|-------------------------------------------------------|
| CORE_AREA                | 2 2 1998 1998                                         |
| DIE_AREA                 | 0 0 2000 2000                                         |
| FILL_CELLS               |                                                       |
| GPL_ROUTABILITY_DRIVEN   | 1                                                     |
| GPL_TIMING_DRIVEN        | 0                                                     |
| HOLD_SLACK_MARGIN        | -200                                                  |
| IO_CONSTRAINTS           | $(location :io-boomtile)                              |
| MACRO_PLACE_HALO         | 19 19                                                 |
| MAX_ROUTING_LAYER        | M7                                                    |
| MIN_ROUTING_LAYER        | M2                                                    |
| PDN_TCL                  | $(PLATFORM_DIR)/openRoad/pdn/BLOCKS_grid_strategy.tcl |
| PLACE_DENSITY            | 0.24                                                  |
| PLACE_PINS_ARGS          | -annealing                                            |
| ROUTING_LAYER_ADJUSTMENT | 0.45                                                  |
| SDC_FILE                 | $(location :constraints-boomtile)                     |
| SETUP_SLACK_MARGIN       | -1300                                                 |
| SKIP_CTS_REPAIR_TIMING   | 1                                                     |
| SKIP_INCREMENTAL_REPAIR  | 1                                                     |
| SKIP_LAST_GASP           | 1                                                     |
| SKIP_REPORT_METRICS      | 1                                                     |
| SYNTH_HIERARCHICAL       | 1                                                     |
| TAPCELL_TCL              |                                                       |
| TNS_END_PERCENT          | 0                                                     |