### PR TITLE
srams: 90 degrees rotation in lieu

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -282,6 +282,9 @@ boom_regfile_rams = {
     orfs_flow(
         name = ram,
         abstract_stage = all_srams_stage,
+        arguments = {
+            "PLACE_PINS_ARGS": "-min_distance 1 -min_distance_in_tracks",
+        },
         stage_arguments = {
             "synth": SRAM_SYNTH_ARGUMENTS,
             "floorplan": BLOCK_FLOORPLAN | {

--- a/io-sram.tcl
+++ b/io-sram.tcl
@@ -1,3 +1,32 @@
+source $::env(SCRIPTS_DIR)/util.tcl
 source util.tcl
 
-set_io_pin_constraint -region left:* -pin_names [match_pins {(R|W)[0-9]+_.*}]
+# By placing the pins at the left edge, then by mirroring on
+# X and Y, it is possible to place the pins in 4 significantly
+# different orientations. In lieu of being able to rotate a
+# macro 90 degrees, this is a good compromise.
+set db [::ord::get_db]
+set block [[$db getChip] getBlock]
+set die_bbox [$block getCoreArea]
+set dbu_per_uu [expr double([[$db getTech] getDbUnitsPerMicron])]
+set scale [expr 1 / $dbu_per_uu]
+#puts $f "width: [expr [$die_bbox xMax] * $scale]"
+#puts $f "height: [expr [$die_bbox yMax] * $scale]"
+set height [expr [$die_bbox yMax] * $scale]
+set width [expr [$die_bbox xMax] * $scale]
+
+set tech [$block getTech]
+if {$height > $width} {
+  set layer [$tech findLayer $::env(IO_PLACER_V)]
+  set pitch [expr [$layer getPitchX] * $scale]
+  set edge_length $height
+  set edge left
+} else {
+  set layer [$tech findLayer $::env(IO_PLACER_H)]
+  set pitch [expr [$layer getPitchY] * $scale]
+  set edge_length $width
+  set edge top
+}
+set pin_names [match_pins {(R|W)[0-9]+_.*}]
+
+log_cmd set_io_pin_constraint -region $edge:0-[expr min($edge_length, $pitch * ([llength $pin_names] + 4) * 1.3)] -pin_names $pin_names


### PR DESCRIPTION
This moved WNS for cts from -2685 to -2852, which is so small a difference as to be inconclusive as to whether it is better or worse, but it is certainly not dramatically better.

It does not look like pin placement has any effect on macro placement, possibly only orentation?

With this change:

![image](https://github.com/user-attachments/assets/952d0ba1-71e3-4ca0-8304-2b3730bdc12d)

Before:

![image](https://github.com/user-attachments/assets/84ddd087-3572-4e8f-a9d3-6e7675cdc28c)


This is global routing congestion-20.rpt

![image](https://github.com/user-attachments/assets/ce54baad-ea5c-4f98-a25a-8435b895612e)



Stage: cts
| Variant                        | base                              | 1                                         |
|--------------------------------|-----------------------------------|-------------------------------------------|
| Description                    | Flattend, timing driven placement | Hierarchical, branch predictors as macros |
| Buffer                         | 118587                            | 246303                                    |
| Clock buffer                   | 12179                             | 20180                                     |
| Clock inverter                 | 3726                              | 6144                                      |
| Inverter                       | 70385                             | 130946                                    |
| Macro                          | 72                                | 42                                        |
| Multi-Input combinational cell | 740179                            | 1263033                                   |
| Sequential cell                | 118443                            | 214014                                    |
| Tie cell                       | 60                                | 1520                                      |
| Timing Repair Buffer           | 69084                             | 80716                                     |
| Total                          | 1132715                           | 1962898                                   |
| slack                          | -2852.557373                      | -5589.279297                              |
| tns                            | -95356312.0                       | -445220320.0                              |
| GPL_TIMING_DRIVEN              | 1                                 |                                           |
| HOLD_SLACK_MARGIN              |                                   | -900                                      |
| MACRO_PLACEMENT_TCL            | $(location write_macro_placement) |                                           |
| MAX_ROUTING_LAYER              |                                   | M9                                        |
| PDN_TCL                        |                                   | $(location :pdn.tcl)                      |
| SKIP_CTS_REPAIR_TIMING         | 0                                 |                                           |
| SKIP_LAST_GASP                 | 0                                 |                                           |
| SYNTH_HIERARCHICAL             | 0                                 |                                           |
| dissolve                       |                                   |                                           |
| previous_stage                 |                                   |                                           |
| 2_1_floorplan.log              | 140                               | 556                                       |
| 2_2_floorplan_io.log           | 21                                | 35                                        |
| 2_3_floorplan_macro.log        | 25                                | 1060                                      |
| 2_4_floorplan_tapcell.log      | 21                                | 34                                        |
| 2_5_floorplan_pdn.log          | 537                               | 145                                       |
| 3_1_place_gp_skip_io.log       | 1367                              | 928                                       |
| 3_2_place_iop.log              | 26                                | 39                                        |
| 3_3_place_gp.log               | 9216                              | 3122                                      |
| 3_4_place_resized.log          | 326                               | 576                                       |
| 3_5_place_dp.log               | 1387                              | 2485                                      |
| 4_1_cts.log                    | 24143                             | 507                                       |

Base configuration variables
| Variable                 | Value                                                 |
|--------------------------|-------------------------------------------------------|
| CORE_AREA                | 2 2 1498 1498                                         |
| DIE_AREA                 | 0 0 1500 1500                                         |
| FILL_CELLS               |                                                       |
| GPL_ROUTABILITY_DRIVEN   | 1                                                     |
| GPL_TIMING_DRIVEN        | 0                                                     |
| HOLD_SLACK_MARGIN        | -200                                                  |
| IO_CONSTRAINTS           | $(location :io-boomtile)                              |
| MACRO_PLACE_HALO         | 19 19                                                 |
| MAX_ROUTING_LAYER        | M7                                                    |
| MIN_ROUTING_LAYER        | M2                                                    |
| PDN_TCL                  | $(PLATFORM_DIR)/openRoad/pdn/BLOCKS_grid_strategy.tcl |
| PLACE_DENSITY            | 0.24                                                  |
| PLACE_PINS_ARGS          | -annealing                                            |
| ROUTING_LAYER_ADJUSTMENT | 0.45                                                  |
| SDC_FILE                 | $(location :constraints-boomtile)                     |
| SETUP_SLACK_MARGIN       | -1300                                                 |
| SKIP_CTS_REPAIR_TIMING   | 1                                                     |
| SKIP_INCREMENTAL_REPAIR  | 1                                                     |
| SKIP_LAST_GASP           | 1                                                     |
| SKIP_REPORT_METRICS      | 1                                                     |
| SYNTH_HIERARCHICAL       | 1                                                     |
| TAPCELL_TCL              |                                                       |
| TNS_END_PERCENT          | 0                                                     |
