### PR TITLE
floorplan: 1250x1250

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -377,32 +377,12 @@ SWEEP = {
         },
         "stage_sources": {"floorplan": ["write_macro_placement"]},
     },
-    "1": {
-        "description": "Hierarchical, branch predictors as macros",
-        "variables": {
-            "HOLD_SLACK_MARGIN": "-900",
-            "PDN_TCL": "$(location :pdn.tcl)",
-            "MAX_ROUTING_LAYER": "M9",
-        },
-        "macros": ["ComposedBranchPredictorBank_generate_abstract"],
-        "stage_sources": {"floorplan": ["pdn.tcl"]},
-    },
-    "2": {
-        "description": "Hierarchical, branch predictors as macros",
-        "variables": {
-            "HOLD_SLACK_MARGIN": "-900",
-            "PDN_TCL": "$(location :pdn.tcl)",
-            "MAX_ROUTING_LAYER": "M9",
-        },
-        "macros": ["BranchPredictor_generate_abstract"],
-        "stage_sources": {"floorplan": ["pdn.tcl"]},
-    },
 }
 
 BOOMTILE_VARIABLES = SKIP_REPORT_METRICS | FAST_BUILD_SETTINGS | {
     "PDN_TCL": "$(PLATFORM_DIR)/openRoad/pdn/BLOCKS_grid_strategy.tcl",
     "IO_CONSTRAINTS": "$(location :io-boomtile)",
-    "PLACE_DENSITY": "0.24",
+    "PLACE_DENSITY": "0.54",
     # We only need hierarchical synthesis when we are running through floorplan
     # write_macro_placement macros.tcl
     "SYNTH_HIERARCHICAL": "1",
@@ -412,8 +392,8 @@ BOOMTILE_VARIABLES = SKIP_REPORT_METRICS | FAST_BUILD_SETTINGS | {
     "MIN_ROUTING_LAYER": "M2",
     "MAX_ROUTING_LAYER": "M7",
     "ROUTING_LAYER_ADJUSTMENT": "0.45",
-    "DIE_AREA": "0 0 1500 1500",
-    "CORE_AREA": "2 2 1498 1498",
+    "DIE_AREA": "0 0 1250 1250",
+    "CORE_AREA": "2 2 1248 1248",
     # Saves hours of build time, specific to BoomTile
     "SKIP_LAST_GASP": "1",
     "SETUP_SLACK_MARGIN": "-1300",

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -377,7 +377,19 @@ SWEEP = {
         },
         "stage_sources": {"floorplan": ["write_macro_placement"]},
     },
-}
+} | {str(i + 1): {
+    "description": "Placement density sweep",
+    "variables": {
+        "SYNTH_HIERARCHICAL": "0",
+        "GPL_TIMING_DRIVEN": "1",
+        "SKIP_CTS_REPAIR_TIMING": "0",
+        "MACRO_PLACEMENT_TCL": "$(location write_macro_placement)",
+        "SKIP_LAST_GASP": "0",
+        "PLACE_DENSITY": str(0.54 + (i + 1) * 0.05),
+    },
+    "previous_stage": {"floorplan": "BoomTile_synth"},
+    "stage_sources": {"floorplan": ["write_macro_placement"]},
+} for i in [0, 1, 2, 3]}
 
 BOOMTILE_VARIABLES = SKIP_REPORT_METRICS | FAST_BUILD_SETTINGS | {
     "PDN_TCL": "$(PLATFORM_DIR)/openRoad/pdn/BLOCKS_grid_strategy.tcl",


### PR DESCRIPTION
PLACE_DENSITY=0.29, routing loops around the register file macro, as previously reported.

![image](https://github.com/user-attachments/assets/761dbe7b-7f28-4387-9a1d-f8102d83140c)


Stage: cts
| Variant                        | base                              | 1                                 | 6                                 |
|--------------------------------|-----------------------------------|-----------------------------------|-----------------------------------|
| Description                    | Flattend, timing driven placement | Placement density sweep           | Placement density sweep           |
| Buffer                         | 118587                            | 118587                            | 118587                            |
| Clock buffer                   | 10860                             | 10860                             | 9410                              |
| Clock inverter                 | 3564                              | 3564                              | 3325                              |
| Inverter                       | 70385                             | 70385                             | 70385                             |
| Macro                          | 72                                | 72                                | 72                                |
| Multi-Input combinational cell | 740179                            | 740179                            | 740179                            |
| Sequential cell                | 118443                            | 118443                            | 118443                            |
| Tie cell                       | 60                                | 60                                | 60                                |
| Timing Repair Buffer           | 40060                             | 40060                             | 20761                             |
| Total                          | 1102210                           | 1102210                           | 1081222                           |
| slack                          | -3148.359863                      | -3148.359863                      | -2493.68457                       |
| tns                            | -79261568.0                       | -79261568.0                       | -62767780.0                       |
| GPL_TIMING_DRIVEN              | 1                                 | 1                                 | 1                                 |
| MACRO_PLACEMENT_TCL            | $(location write_macro_placement) | $(location write_macro_placement) | $(location write_macro_placement) |
| PLACE_DENSITY                  | 0.29                              | 0.29                              | 0.54                              |
| SKIP_CTS_REPAIR_TIMING         | 0                                 | 0                                 | 0                                 |
| SKIP_LAST_GASP                 | 0                                 | 0                                 | 0                                 |
| SYNTH_HIERARCHICAL             | 0                                 | 0                                 | 0                                 |
| dissolve                       |                                   |                                   |                                   |
| previous_stage                 |                                   | floorplan: BoomTile_synth         | floorplan: BoomTile_synth         |
| 2_1_floorplan.log              | 131                               | 144                               | 135                               |
| 2_2_floorplan_io.log           | 19                                | 21                                | 19                                |
| 2_3_floorplan_macro.log        | 21                                | 23                                | 21                                |
| 2_4_floorplan_tapcell.log      | 18                                | 19                                | 18                                |
| 2_5_floorplan_pdn.log          | 589                               | 635                               | 599                               |
| 3_1_place_gp_skip_io.log       | 401                               | 474                               | 1122                              |
| 3_2_place_iop.log              | 23                                | 25                                | 23                                |
| 3_3_place_gp.log               | 4853                              | 5061                              | 4944                              |
| 3_4_place_resized.log          | 310                               | 311                               | 314                               |
| 3_5_place_dp.log               | 729                               | 777                               | 1433                              |
| 4_1_cts.log                    | 537                               | 548                               | 3685                              |

Base configuration variables
| Variable                 | Value                                                 |
|--------------------------|-------------------------------------------------------|
| CORE_AREA                | 2 2 1248 1248                                         |
| DIE_AREA                 | 0 0 1250 1250                                         |
| FILL_CELLS               |                                                       |
| GPL_ROUTABILITY_DRIVEN   | 1                                                     |
| GPL_TIMING_DRIVEN        | 0                                                     |
| HOLD_SLACK_MARGIN        | -200                                                  |
| IO_CONSTRAINTS           | $(location :io-boomtile)                              |
| MACRO_PLACE_HALO         | 19 19                                                 |
| MAX_ROUTING_LAYER        | M7                                                    |
| MIN_ROUTING_LAYER        | M2                                                    |
| PDN_TCL                  | $(PLATFORM_DIR)/openRoad/pdn/BLOCKS_grid_strategy.tcl |
| PLACE_DENSITY            | 0.24                                                  |
| PLACE_PINS_ARGS          | -annealing                                            |
| ROUTING_LAYER_ADJUSTMENT | 0.45                                                  |
| SDC_FILE                 | $(location :constraints-boomtile)                     |
| SETUP_SLACK_MARGIN       | -1300                                                 |
| SKIP_CTS_REPAIR_TIMING   | 1                                                     |
| SKIP_INCREMENTAL_REPAIR  | 1                                                     |
| SKIP_LAST_GASP           | 1                                                     |
| SKIP_REPORT_METRICS      | 1                                                     |
| SYNTH_HIERARCHICAL       | 1                                                     |
| TAPCELL_TCL              |                                                       |
| TNS_END_PERCENT          | 0                                                     |

