### PR TITLE
floorplan: 1250x1250

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -377,32 +377,12 @@ SWEEP = {
         },
         "stage_sources": {"floorplan": ["write_macro_placement"]},
     },
-    "1": {
-        "description": "Hierarchical, branch predictors as macros",
-        "variables": {
-            "HOLD_SLACK_MARGIN": "-900",
-            "PDN_TCL": "$(location :pdn.tcl)",
-            "MAX_ROUTING_LAYER": "M9",
-        },
-        "macros": ["ComposedBranchPredictorBank_generate_abstract"],
-        "stage_sources": {"floorplan": ["pdn.tcl"]},
-    },
-    "2": {
-        "description": "Hierarchical, branch predictors as macros",
-        "variables": {
-            "HOLD_SLACK_MARGIN": "-900",
-            "PDN_TCL": "$(location :pdn.tcl)",
-            "MAX_ROUTING_LAYER": "M9",
-        },
-        "macros": ["BranchPredictor_generate_abstract"],
-        "stage_sources": {"floorplan": ["pdn.tcl"]},
-    },
 }
 
 BOOMTILE_VARIABLES = SKIP_REPORT_METRICS | FAST_BUILD_SETTINGS | {
     "PDN_TCL": "$(PLATFORM_DIR)/openRoad/pdn/BLOCKS_grid_strategy.tcl",
     "IO_CONSTRAINTS": "$(location :io-boomtile)",
-    "PLACE_DENSITY": "0.24",
+    "PLACE_DENSITY": "0.54",
     # We only need hierarchical synthesis when we are running through floorplan
     # write_macro_placement macros.tcl
     "SYNTH_HIERARCHICAL": "1",
@@ -412,8 +392,8 @@ BOOMTILE_VARIABLES = SKIP_REPORT_METRICS | FAST_BUILD_SETTINGS | {
     "MIN_ROUTING_LAYER": "M2",
     "MAX_ROUTING_LAYER": "M7",
     "ROUTING_LAYER_ADJUSTMENT": "0.45",
-    "DIE_AREA": "0 0 1500 1500",
-    "CORE_AREA": "2 2 1498 1498",
+    "DIE_AREA": "0 0 1250 1250",
+    "CORE_AREA": "2 2 1248 1248",
     # Saves hours of build time, specific to BoomTile
     "SKIP_LAST_GASP": "1",
     "SETUP_SLACK_MARGIN": "-1300",


### PR DESCRIPTION
place density 0.69 is the end of the line, 0.73 didn't make it past placement.

Looks like the diea area could come down a bit more.

![image](https://github.com/user-attachments/assets/51040717-cfa6-415d-ba7d-40952cf959cd)

![image](https://github.com/user-attachments/assets/656f5275-8acf-4f79-aa22-03e6aa846ed0)



Stage: cts
| Variant                        | base                              | 1                                 | 2                                 | 3                                 |
|--------------------------------|-----------------------------------|-----------------------------------|-----------------------------------|-----------------------------------|
| Description                    | Flattend, timing driven placement | Placement density sweep           | Placement density sweep           | Placement density sweep           |
| Buffer                         | 118587                            | 118587                            | 118587                            | 118586                            |
| Clock buffer                   | 9315                              | 9681                              | 9446                              | 9293                              |
| Clock inverter                 | 3591                              | 3112                              | 3134                              | 3059                              |
| Inverter                       | 70385                             | 70385                             | 70385                             | 70385                             |
| Macro                          | 72                                | 72                                | 72                                | 72                                |
| Multi-Input combinational cell | 740179                            | 740180                            | 740180                            | 740180                            |
| Sequential cell                | 118443                            | 118443                            | 118443                            | 118443                            |
| Tie cell                       | 60                                | 60                                | 60                                | 60                                |
| Timing Repair Buffer           | 24308                             | 27643                             | 26905                             | 26365                             |
| Total                          | 1084940                           | 1088163                           | 1087212                           | 1086443                           |
| slack                          | -3158.438965                      | -2561.701172                      | -2363.587646                      | -2220.7854                        |
| tns                            | -73953728.0                       | -63354296.0                       | -60619804.0                       | -54036328.0                       |
| GPL_TIMING_DRIVEN              | 1                                 | 1                                 | 1                                 | 1                                 |
| MACRO_PLACEMENT_TCL            | $(location write_macro_placement) | $(location write_macro_placement) | $(location write_macro_placement) | $(location write_macro_placement) |
| PLACE_DENSITY                  |                                   | 0.5900000000000001                | 0.64                              | 0.6900000000000001                |
| SKIP_CTS_REPAIR_TIMING         | 0                                 | 0                                 | 0                                 | 0                                 |
| SKIP_LAST_GASP                 | 0                                 | 0                                 | 0                                 | 0                                 |
| SYNTH_HIERARCHICAL             | 0                                 | 0                                 | 0                                 | 0                                 |
| dissolve                       |                                   |                                   |                                   |                                   |
| previous_stage                 |                                   | floorplan: BoomTile_synth         | floorplan: BoomTile_synth         | floorplan: BoomTile_synth         |
| 2_1_floorplan.log              | 138                               | 138                               | 138                               | 138                               |
| 2_2_floorplan_io.log           | 20                                | 20                                | 20                                | 20                                |
| 2_3_floorplan_macro.log        | 22                                | 22                                | 22                                | 22                                |
| 2_4_floorplan_tapcell.log      | 18                                | 18                                | 18                                | 18                                |
| 2_5_floorplan_pdn.log          | 647                               | 647                               | 647                               | 650                               |
| 3_1_place_gp_skip_io.log       | 1212                              | 1361                              | 1482                              | 1567                              |
| 3_2_place_iop.log              | 25                                | 28                                | 29                                | 29                                |
| 3_3_place_gp.log               | 5325                              | 4817                              | 4886                              | 4902                              |
| 3_4_place_resized.log          | 328                               | 303                               | 304                               | 303                               |
| 3_5_place_dp.log               | 1512                              | 818                               | 809                               | 851                               |
| 4_1_cts.log                    | 652                               | 523                               | 709                               | 3859                              |

Base configuration variables
| Variable                 | Value                                                 |
|--------------------------|-------------------------------------------------------|
| CORE_AREA                | 2 2 1248 1248                                         |
| DIE_AREA                 | 0 0 1250 1250                                         |
| FILL_CELLS               |                                                       |
| GPL_ROUTABILITY_DRIVEN   | 1                                                     |
| GPL_TIMING_DRIVEN        | 0                                                     |
| HOLD_SLACK_MARGIN        | -200                                                  |
| IO_CONSTRAINTS           | $(location :io-boomtile)                              |
| MACRO_PLACE_HALO         | 19 19                                                 |
| MAX_ROUTING_LAYER        | M7                                                    |
| MIN_ROUTING_LAYER        | M2                                                    |
| PDN_TCL                  | $(PLATFORM_DIR)/openRoad/pdn/BLOCKS_grid_strategy.tcl |
| PLACE_DENSITY            | 0.54                                                  |
| PLACE_PINS_ARGS          | -annealing                                            |
| ROUTING_LAYER_ADJUSTMENT | 0.45                                                  |
| SDC_FILE                 | $(location :constraints-boomtile)                     |
| SETUP_SLACK_MARGIN       | -1300                                                 |
| SKIP_CTS_REPAIR_TIMING   | 1                                                     |
| SKIP_INCREMENTAL_REPAIR  | 1                                                     |
| SKIP_LAST_GASP           | 1                                                     |
| SKIP_REPORT_METRICS      | 1                                                     |
| SYNTH_HIERARCHICAL       | 1                                                     |
| TAPCELL_TCL              |                                                       |
| TNS_END_PERCENT          | 0                                                     |
